### PR TITLE
fix(github-actions): fix CVE-2025-30066 and pre-emptive security measures

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -126,7 +126,7 @@ jobs:
         CACHE_PARAMS: image-manifest=true,oci-mediatypes=true,mode=max,compression=zstd
       # yamllint disable-line rule:indentation
       run: |
-        if [[ "$IMAGE_CACHE" == '' || "$CONNECT_TAILSCALE" != 'true' ]]; then
+        if [[ "$IMAGE_CACHE" == '' || "$CONNECT_TAILSCALE" != 'true' || "$PUBLISH_PRIVATE_REGISTRY" != 'true' ]]; then
           echo "No repository for docker build cache specified, disabling build cache all together."
           CACHE_FROM=""
           CACHE_TO=""

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Determine what files types have changed
       id: changed-files-yaml
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           actions:
@@ -80,6 +80,14 @@ jobs:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.docker_all_changed_files }}
 
+  markdown:
+    needs: [detect-changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.markdown_any_changed == 'true' }}
+    uses: ./.github/workflows/lint-markdown.yaml
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}
+      files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.markdown_all_changed_files }}
+
   pre-commit:
     uses: ./.github/workflows/lint-pre-commit.yaml
     with:
@@ -115,11 +123,3 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.yaml_all_changed_files }}
-
-  markdown:
-    needs: [detect-changes]
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.markdown_any_changed == 'true' }}
-    uses: ./.github/workflows/lint-markdown.yaml
-    with:
-      git_ref: ${{ github.head_ref || github.ref }}
-      files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.markdown_all_changed_files }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -115,6 +115,7 @@ jobs:
     uses: ppat/github-workflows/.github/workflows/lint-terraform.yaml@main
     with:
       git_ref: ${{ github.head_ref || github.ref }}
+      tf_dirs: ""
 
   yaml:
     needs: [detect-changes]


### PR DESCRIPTION
- Fix CVE-2025-30066 by upgrading to tj-actions/changed-files to v46
- Rotate all secrets used in Github Actions
- Explicitly set permission for default GITHUB_TOKEN to limit its capabilities to only whats needed