### PR TITLE
chore(github-actions): update actions/checkout (v4 -> v7.0.0) and actions/create-github-app-token (v2 -> v3.2.0)

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
         persist-credentials: false

--- a/.github/workflows/detect-changed-files.yaml
+++ b/.github/workflows/detect-changed-files.yaml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ github.repository }}
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/lint-commit-messages.yaml
+++ b/.github/workflows/lint-commit-messages.yaml
@@ -62,7 +62,7 @@ jobs:
           bun               = true
 
     - name: Checkout github-workflows
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
         path: tools

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Generate github app token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ secrets.app_id }}

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -49,7 +49,7 @@ jobs:
       released_gitref: ${{ steps.release_info.outputs.gitref }}
     steps:
     - name: Generate github app token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ secrets.app_id }}
@@ -74,7 +74,7 @@ jobs:
           bun               = true
 
     - name: Checkout github-workflows
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
         path: tools

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     steps:
     - name: Generate github app token for renovate
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ secrets.app_id }}
@@ -43,7 +43,7 @@ jobs:
         owner: ${{ github.repository_owner }}
 
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
         repository: ${{ github.repository }}

--- a/.github/workflows/update-aqua-checksums.yaml
+++ b/.github/workflows/update-aqua-checksums.yaml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Generate github app token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ secrets.app_id }}


### PR DESCRIPTION
Pin actions/checkout and actions/create-github-app-token to their latest major versions using full semver in the digest comment, matching renovate's pinGitHubActionDigests expectations.

- actions/checkout v4 -> v7.0.0: adds allow-unsafe-pr-checkout input (default false, no-op here since no pull_request_target/workflow_run triggers are used), migrates to node24 runtime.
- actions/create-github-app-token v2 -> v3.2.0: migrates to node24 runtime, deprecates app-id in favor of client-id (not used here so no change needed), adds NODE_USE_ENV_PROXY requirement for proxy support (not used here so no change needed).

Both require Actions Runner >= v2.327.1, which is satisfied by GitHub-hosted ubuntu-24.04/ubuntu-latest runners already in use; no self-hosted runners exist in this repo, so no runs-on changes are needed.