### PR TITLE
feat(github-actions): update renovatebot/github-action (v44.2.6 -> v46.1.17)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -51,11 +51,11 @@ jobs:
         token: "${{ steps.app-token.outputs.token }}"
 
     - name: Renovate
-      uses: renovatebot/github-action@eaf12548c13069dcc28bb75c4ee4610cdbe400c5 # v44.2.6
+      uses: renovatebot/github-action@dd5302ec17783b2fc721b19ae7209b57b1587765 # v46.1.17
       with:
         token: ${{ steps.app-token.outputs.token }}
         # renovate: datasource=github-releases depName=renovatebot/renovate
-        renovate-version: "43.233.3"
+        renovate-version: "43.251.3"
       env:
         LOG_LEVEL: ${{ inputs.log_level }}
         RENOVATE_DRY_RUN: "${{ inputs.dry_run && 'extract' || '' }}"
@@ -76,7 +76,7 @@ jobs:
             }
           ]
         RENOVATE_PLATFORM: 'github'
-        RENOVATE_PLATFORM_COMMIT: 'true'
+        RENOVATE_PLATFORM_COMMIT: 'enabled'
         RENOVATE_REPOSITORIES: "${{ github.repository }}"
         RENOVATE_REQUIRE_CONFIG: 'required'
         GIT_AUTHOR_NAME: ""


### PR DESCRIPTION
Updates renovatebot/github-action to the latest version, pinned with full semver in the digest comment per renovate's
pinGitHubActionDigests expectations.

Also updates RENOVATE_PLATFORM_COMMIT from the deprecated 'true' value to 'enabled', per guidance added in github-action v46.1.14 (renovatebot/github-action#1029). The old value still works but now emits a deprecation warning:
  WARN: env config platformCommit property has been changed to enabled

Breaking changes reviewed across v45.0.0 and v46.0.0:
- v45.0.0: migrated to Node 24 runtime, requiring Actions Runner
  >= v2.327.1 (satisfied by GitHub-hosted ubuntu-24.04 runners already
  in use; no self-hosted runners exist in this repo).
- v46.0.0: bumped the *default* renovate-version docker tag to v43. This workflow already pins an explicit renovate-version input (43.233.3), so the new default has no effect here.