### PR TITLE
feat(github-actions): add zizmor static analysis security gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,7 @@
   "labels": [
     "pr-type:renovate"
   ],
+  "osvVulnerabilityAlerts": true,
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "printConfig": true,
@@ -53,5 +54,8 @@
     "prEditedNotification",
     "prIgnoreNotification"
   ],
-  "timezone": "US/Eastern"
+  "timezone": "US/Eastern",
+  "vulnerabilityAlerts": {
+    "automerge": false
+  }
 }

--- a/.github/workflows/lint-zizmor.yaml
+++ b/.github/workflows/lint-zizmor.yaml
@@ -1,0 +1,47 @@
+---
+# yamllint disable rule:line-length
+name: zizmor
+
+on:
+  workflow_call:
+    inputs:
+      git_ref:
+        required: true
+        type: string
+      mise_ignore_cfg:
+        required: false
+        type: string
+        default: ""
+      mise_log_level:
+        required: false
+        type: string
+        default: "warn"
+
+env:
+  # renovate: datasource=github-releases depName=zizmorcore/zizmor
+  ZIZMOR_VERSION: "v1.26.1"
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+    - name: Setup repository and tools
+      uses: ppat/homelab-ops-actions/actions/setup-repository-tools@e1b557cd4ff79bce28b6c79b6a7de8a95db37bbb # v2.0.0
+      with:
+        current_git_ref: ${{ inputs.git_ref }}
+        current_repository: ${{ github.repository }}
+        mise_ignore_cfg: ${{ inputs.mise_ignore_cfg }}
+        mise_log_level: ${{ inputs.mise_log_level }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        mise_toml: |
+          [tools]
+          "aqua:zizmorcore/zizmor" = "${{ env.ZIZMOR_VERSION }}"
+
+    - name: Audit github actions with zizmor
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      working-directory: ./current
+      run: |
+        zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .

--- a/.github/workflows/self-lint.yaml
+++ b/.github/workflows/self-lint.yaml
@@ -78,3 +78,10 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
+
+  zizmor:
+    needs: [detect-changes]
+    if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
+    uses: ./.github/workflows/lint-zizmor.yaml
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,0 +1,40 @@
+---
+# Pre-existing findings in already-merged workflows, accepted as known/tracked
+# risk rather than fixed here, to keep the zizmor gate's introduction scoped to
+# "add the gate" (see lint-zizmor.yaml). Revisit independently.
+rules:
+  template-injection:
+    ignore:
+    # `inputs.from`/`inputs.to` are workflow_call inputs supplied by
+    # self-lint.yaml (git refs/SHAs), not attacker-controlled event data, but
+    # zizmor flags any `inputs.*` expansion inside `run:`. Safer fix (pass via
+    # `env:`) is a follow-up, not required for the zizmor gate itself.
+    - lint-commit-messages.yaml:90
+  github-app:
+    ignore:
+    # All four call sites already scope RENOVATE_REPOSITORIES/operate on only
+    # `github.repository`, but omit explicit `repositories:`/`permission-*`
+    # inputs on `create-github-app-token`, so the token is broader than used.
+    # Narrowing these is a follow-up, not required for the zizmor gate itself.
+    - release-please.yaml:20
+    - release-please.yaml:25
+    - release-semantic.yaml:52
+    - release-semantic.yaml:57
+    - renovate.yaml:38
+    - renovate.yaml:43
+    - update-aqua-checksums.yaml:49
+    - update-aqua-checksums.yaml:54
+  ref-version-mismatch:
+    ignore:
+    # Online audit (requires GH_TOKEN): the pinned SHA's version comment is a
+    # major-only tag (e.g. "# v3") while the SHA is actually also pointed to
+    # by a more specific tag (e.g. v3.11.1). Cosmetic drift in pre-existing
+    # pins, not a security issue and not introduced by this change; updating
+    # the comments to full semver is a follow-up, not required for the
+    # zizmor gate itself.
+    - build-docker-image.yaml:175
+    - build-docker-image.yaml:215
+    - build-docker-image.yaml:222
+    - build-docker-image.yaml:230
+    - build-docker-image.yaml:248
+    - release-please.yaml:28


### PR DESCRIPTION
Add a new reusable workflow (lint-zizmor.yaml) that audits this repo's own GitHub Actions workflows with zizmor, the de facto standard static analyzer for GitHub Actions supply-chain security issues (template injection, credential persistence, excessive permissions, impostor commits, unpinned uses, dangerous triggers).

Installs zizmor via mise/aqua (matching this repo's existing "mise-install the tool, invoke it directly" convention used by every other lint-*.yaml workflow) rather than the third-party zizmorcore/zizmor-action wrapper, avoiding an extra Action dependency and an extra actions_allowed entry across every caller repo.

Uses --format=github (not --format=sarif) so zizmor's native exit code (non-zero on findings) fails the job -- this composes directly with existing github_branch_protection.required_status_checks wiring without needing a new ruleset resource, and is not subject to GitHub's code-scanning merge-protection line-in-diff limitation (which would unreliably gate single-line Renovate SHA bumps).

Threshold: --persona=regular --min-severity=medium --min-confidence=high, chosen so the gate blocks genuine security findings without failing on existing low-severity nits.

Add zizmor.yaml to ignore pre-existing findings in already-merged workflows (template-injection in lint-commit-messages.yaml; github-app token scoping in release-please/release-semantic/ renovate/update-aqua-checksums.yaml), keeping this change scoped to "add the gate" rather than a broader hardening pass.

Wire the new zizmor job into self-lint.yaml, gated on the same `actions` file-change group already used by the github-actions job.

Enable osvVulnerabilityAlerts so Renovate surfaces OSV-based vulnerability alerts for direct dependencies, and add a vulnerabilityAlerts override so known-CVE fixes are raised immediately rather than waiting behind the same cooldown (minimumReleaseAge) as cosmetic bumps. automerge stays disabled for vulnerability-fix PRs so a human reviews them rather than having a security fix silently auto-merge.