### PR TITLE
docs: add CLAUDE.md and DESIGN.md, expand README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [README.md](README.md) for what each workflow does and how to call one from a consuming repo, and
+[DESIGN.md](DESIGN.md) for conventions and how release/renovate/testing fit together.
+
+## Repo layout
+
+- `.github/workflows/*.yaml` — the reusable workflows themselves (`on: workflow_call`), one per file,
+  e.g. `lint-yaml.yaml`, `build-docker-image.yaml`, `release-please.yaml`. These are the product of this
+  repo; everything else supports or exercises them.
+- `.github/workflows/self-*.yaml` — this repo consuming its own reusable workflows, either as tests
+  against fixtures in `test/`, or as this repo's actual lint/release/renovate CI. See
+  [DESIGN.md](DESIGN.md) for which is which.
+- `test/<name>/` — fixtures for the matching `self-test-<name>.yaml` (e.g. `test/docker/Dockerfile`,
+  `test/terraform/*.tf`, `test/chainsaw/*.yaml`).
+- `.github/renovate.json` + `.github/renovate/*.json` — this repo's own Renovate config (also a template
+  for consumers).
+- `.releaserc.js`, `package.json`, `bun.lock` — config/deps for `release-semantic.yaml`, checked out by
+  consumers of that workflow that don't have their own (see the `Install node packages` step in
+  `release-semantic.yaml` and `lint-commit-messages.yaml`).
+- `release-please-config.json`, `.release-please-manifest.json` — config for `release-please.yaml`, used
+  both by consumers and by this repo's own `self-release-please.yaml`.
+- `zizmor.yaml` — accepted-risk findings for the `lint-zizmor.yaml` gate (see comment in the file).
+
+## Commands
+
+No build step. `pre-commit` (yamllint, markdownlint-cli2, shellcheck, commitlint) is the primary local
+tooling:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+pre-commit run yamllint --all-files
+pre-commit run shellcheck --all-files
+pre-commit run markdownlint-cli2 --all-files
+```
+
+Lint a commit message locally:
+
+```bash
+echo "fix(github-actions): pin actions/checkout to v7" | npx commitlint
+```
+
+`bun install` is only needed if changing `package.json`/`.releaserc.js` (semantic-release deps); it is not
+required to edit or lint workflow YAML.
+
+There is no way to run a `workflow_call` workflow locally — to exercise one's actual runtime behavior,
+push a branch/PR that touches it (or its `test/<name>/` fixtures), which triggers the matching
+`self-test-<name>.yaml` in GitHub Actions. These also run weekly and via `workflow_dispatch`, so a
+passing run days ago doesn't guarantee the workflow still works against current upstream tool versions.
+
+## Working in this repo
+
+- Every reusable workflow takes `git_ref` (or `source_git_ref`) as an explicit input rather than assuming
+  `github.ref` — this is what lets `self-test-*.yaml` call a workflow against a PR branch instead of
+  `main`. When adding a new workflow, follow this pattern rather than reading `github.ref` directly inside
+  the called workflow.
+- When changing a reusable workflow's inputs, outputs, or secrets, update its matching table row in
+  [README.md](README.md) in the same change — README is the interface contract consumers read before
+  wiring a `with:`/`secrets:` block, not just a summary.
+- If a workflow's runtime behavior changed (not just its `with:`/`secrets:` surface), check whether a
+  matching `self-test-<name>.yaml` + `test/<name>/` fixture exists and update it rather than relying on
+  manual verification — see [DESIGN.md](DESIGN.md) for the dogfooding pattern this repo uses.
+- Any tool version embedded in a workflow's `env:` (not a lockfile) needs a
+  `# renovate: datasource=... depName=...` comment above it so Renovate's custom regex manager can track
+  it — copy the pattern from an existing workflow (e.g. `HADOLINT_VERSION` in `lint-hadolint.yaml`) rather
+  than inventing a new comment format.
+- Pin any new third-party Action reference to a commit SHA with the version as a trailing comment
+  (`uses: owner/repo@<sha> # vX.Y.Z`).
+- Commit messages must pass commitlint: conventional-commit format, scope must be one of `dev-tools`,
+  `github-actions`, `release`, `renovate`, or empty, header ≤120 chars. `CHANGELOG.md` and version numbers
+  are otherwise fully automated by release-please (this repo's own release mechanism, see
+  [DESIGN.md](DESIGN.md)) — don't hand-edit either.
+- This repo offers both `release-please.yaml` and `release-semantic.yaml` as reusable workflows for
+  consumers to pick one from, but only dogfoods `release-please` on itself. Don't assume the two are
+  interchangeable or that a change to one should mirror in the other — they're deliberately separate
+  mechanisms for consumers with different preferences.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,125 @@
+# Design
+
+## Purpose
+
+This repo hosts reusable GitHub Actions workflows (`workflow_call`) consumed by other `homelab-ops`/`ppat`
+repositories for linting, testing, building, and releasing. Workflows live here — rather than duplicated
+inline in every consuming repo — so the CI/CD logic itself can be versioned, pinned by tag or SHA, and
+changed in one place.
+
+See [README.md](README.md) for what each workflow does and how to call one from a consuming repo, and
+[CLAUDE.md](CLAUDE.md) for repo layout when working with Claude Code.
+
+## Conventions used by the workflows themselves
+
+- Every workflow in `.github/workflows/*.yaml` is a single `on: workflow_call` job graph — no composite
+  actions, no shared scripts outside the workflow file. Anything that needs checking out a repo and
+  installing a toolchain calls
+  [`ppat/homelab-ops-actions`](https://github.com/ppat/homelab-ops-actions)'s
+  `actions/setup-repository-tools@<pinned-sha>` (that action lives in a separate repo specifically so both
+  `github-workflows` and its consumers can use the same checkout/`mise`-install/cache logic).
+- Tool versions needed inside a workflow's `run:` steps are pinned as workflow `env:` values with a
+  `# renovate: datasource=... depName=...` comment directly above, driving the custom regex manager in
+  `.github/renovate.json`. This is what lets Renovate bump a version embedded in shell/YAML instead of a
+  lockfile entry. No reusable workflow exposes a tool-version override as a `workflow_call` input — see
+  "Tool versions are centralized" below for why.
+- Third-party Actions (`actions/checkout`, `docker/build-push-action`, etc.) are pinned to a commit SHA
+  with the version as a trailing comment, per this repo's own `helpers:pinGitHubActionDigests` /
+  `docker:pinDigests` Renovate presets.
+- `detect-changed-files.yaml` exists so consumers (including this repo's own `self-lint.yaml`) can gate
+  expensive lint jobs on `paths` actually changed in a PR, via
+  [`tj-actions/changed-files`](https://github.com/tj-actions/changed-files), rather than running every
+  linter on every PR regardless of what changed.
+- `zizmor.yaml` findings already present when the zizmor gate (`lint-zizmor.yaml`) was introduced are
+  tracked as accepted risk in `zizmor.yaml` (the config file, not the workflow) rather than fixed
+  retroactively — see the comment at the top of that file for the reasoning per finding.
+
+## Tool versions are centralized, not overridden by consumers
+
+No reusable workflow exposes a dedicated per-call tool-version input (e.g. there is no `yamllint_version:`
+input on `lint-yaml.yaml`). Versions default from this repo's own Renovate-tracked `env:` values, passed
+into `setup-repository-tools`' `mise_toml:` input. A consuming repo's own workflow that calls
+`uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@<sha>` has that `<sha>` tracked by Renovate
+too (via `helpers:pinGitHubActionDigests`), so a version bump merged here eventually reaches every consumer
+as a routine Renovate PR bumping their pinned SHA — no per-repo action needed.
+
+Consumers *can* still override a version without any workflow-side input: `mise` (via `jdx/mise-action`
+inside `setup-repository-tools`) auto-discovers and merges any `mise.toml`-style config file anywhere in
+the checked-out repo tree, not just at its root, so a consumer only needs to commit their own `mise.toml`
+(e.g. pinning `yamllint` to an older version) for it to take effect on top of the workflow's inline
+`mise_toml:` defaults. `mise_ignore_cfg` exists on every reusable workflow specifically to suppress that
+auto-discovery for a given path, when a consumer's own committed mise config would otherwise interfere
+with a reusable workflow that expects to fully control its own toolchain. In practice this override path is
+rare — most consumers take the default version and let Renovate carry it forward — but it is a real,
+supported mechanism, not a gap.
+
+## Dogfooding: `self-*.yaml`
+
+Every reusable workflow that has runtime behavior worth exercising has a matching `self-*.yaml` in
+`.github/workflows/` that calls it directly against this repo's own files or the fixtures in `test/`:
+
+- `self-lint.yaml` calls the `lint-*.yaml` workflows (gated by `detect-changed-files.yaml`) against this
+  repo's own workflow/markdown/YAML/renovate-config files, on every PR plus a weekly schedule.
+- `self-test-docker.yaml`, `self-test-chainsaw.yaml`, `self-test-terraform.yaml`, `self-test-shellcheck.yaml`,
+  `self-test-aqua.yaml`, `self-test-semantic-release.yaml` each call one workflow against a fixture tree
+  under `test/<name>/`, triggered by `pull_request.paths` scoped to that workflow + its fixtures, a weekly
+  `schedule`, and `workflow_dispatch`. The weekly run exists to catch upstream drift (a new tool release, an
+  external API change) between PRs that would otherwise go unnoticed until the next unrelated change to
+  that workflow.
+- `self-release-please.yaml` and `self-renovate.yaml` wire this repo's own release and dependency-update
+  automation — see below. They are not "tests"; they're this repo consuming its own reusable workflows for
+  its own repo lifecycle.
+
+When adding a new reusable workflow with meaningful runtime behavior, add a matching `self-test-<name>.yaml`
+and fixtures under `test/<name>/` rather than relying on manual verification.
+
+## Release & versioning
+
+This repo offers **two independent release mechanisms** as reusable workflows, both read conventional-commit
+history, and both remain actively maintained here — this is a deliberate, unhurried mid-migration state, not
+an oversight:
+
+- `release-please.yaml` wraps
+  [`googleapis/release-please-action`](https://github.com/googleapis/release-please-action): PR-based —
+  commits land on a standing release PR that captures the pending changelog/version bump, and merging that
+  PR is what cuts the release. Signed commits are the default behavior, not a workaround. It also natively
+  supports monorepos, including both same-version-across-all-components and independently-versioned
+  components, which `semantic-release` has no real equivalent for. This repo releases **itself** this way —
+  `self-release-please.yaml` runs it on every push to `main`, driven by `release-please-config.json` /
+  `.release-please-manifest.json`.
+- `release-semantic.yaml` wraps
+  [`semantic-release`](https://github.com/semantic-release/semantic-release) (config in `.releaserc.js`,
+  dependencies in `package.json`/`bun.lock`): commit-driven, releases immediately on `workflow_dispatch`
+  without a batching PR, and needs a convoluted plugin workaround to produce a signed commit at all. This
+  repo does **not** use this workflow for its own releases — `self-test-semantic-release.yaml` only dry-runs
+  it on PRs that touch the workflow or its config, to confirm it still works for consumers who use it as
+  their primary release mechanism.
+
+Newer repos in this org default to `release-please`; most older repos still use `release-semantic` and
+haven't been migrated. That migration is intentionally not being rushed: `release-please` is the better fit
+on features (see above), but `semantic-release` has the larger community, and `release-please` being a
+Google product carries its own risk — Google has a track record of discontinuing tools with little notice,
+leaving adopters to deal with the fallout. Both workflows are kept working and tested (`self-*`/`self-test-*`
+above) rather than one being left to bit-rot in favor of the other. Don't take on a wholesale migration of
+consumer repos from one to the other without being asked — pick whichever mechanism a given repo already
+uses, or ask, rather than assuming `release-please` is always the right default going forward.
+
+Commit messages are enforced by commitlint (`commitlint.config.js`, scopes limited to
+`dev-tools`/`github-actions`/`release`/`renovate`/empty) via `lint-commit-messages.yaml`. `CHANGELOG.md` and
+version numbers are fully automated by whichever mechanism a repo uses — don't hand-edit either.
+
+## Dependency updates
+
+`renovate.yaml` wraps [`renovatebot/github-action`](https://github.com/renovatebot/github-action) as a
+reusable workflow for consumers. This repo also consumes it on itself via `self-renovate.yaml` (daily
+schedule, dry-run on PRs touching the workflow), using `.github/renovate.json`, which extends shared
+presets from [`ppat/renovate-presets`](https://github.com/ppat/renovate-presets) plus three local overlay
+files: `.github/renovate/group.json` (groups related npm packages into one PR),
+`.github/renovate/release-age.json` (minimum release age before some major/minor bumps are opened), and
+`.github/renovate/exceptions.json` (version ceilings for tools with known compatibility constraints, each
+with a `description` explaining why).
+
+`update-aqua-checksums.yaml` is a separate reusable workflow (not part of the Renovate config) that keeps
+`aqua-checksum.json` lockfiles current for repos using [`aqua`](https://aquaproj.github.io/) as a tool
+installer — Renovate bumps the version in `aqua.yaml`, this workflow recomputes the checksums and pushes a
+signed commit via `ppat/homelab-ops-actions`'s `actions/create-signed-commit`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,62 @@
 # github-workflows
 
-Reusable workflows for homelab.
+Reusable [GitHub Actions `workflow_call` workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+for CI/CD across the `homelab-ops` and `ppat` GitHub organizations/repos: linting, testing, Docker builds,
+releases, and dependency updates.
+
+## Workflows
+
+| Workflow | Description |
+| --- | --- |
+| [`build-docker-image.yaml`](.github/workflows/build-docker-image.yaml) | Build and optionally push a multi-platform Docker image (Docker Hub and/or a private registry over Tailscale), with registry-backed layer caching and OCI labels/annotations derived from the git ref. |
+| [`chainsaw-test.yaml`](.github/workflows/chainsaw-test.yaml) | Spin up a `kind` cluster with Flux installed and run [`kyverno/chainsaw`](https://github.com/kyverno/chainsaw) tests against it. |
+| [`detect-changed-files.yaml`](.github/workflows/detect-changed-files.yaml) | Wrap [`tj-actions/changed-files`](https://github.com/tj-actions/changed-files) so downstream jobs can gate on which paths changed in a PR. |
+| [`lint-commit-messages.yaml`](.github/workflows/lint-commit-messages.yaml) | Lint a commit range with `commitlint`. |
+| [`lint-github-actions.yaml`](.github/workflows/lint-github-actions.yaml) | Lint workflow/action YAML with `actionlint` (shellcheck-integrated). |
+| [`lint-hadolint.yaml`](.github/workflows/lint-hadolint.yaml) | Lint Dockerfiles with `hadolint`. |
+| [`lint-markdown.yaml`](.github/workflows/lint-markdown.yaml) | Lint Markdown with `markdownlint-cli2`. |
+| [`lint-pre-commit.yaml`](.github/workflows/lint-pre-commit.yaml) | Run a fixed set of generic `pre-commit-hooks` (large files, shebangs, JSON, private keys, EOF, line endings, whitespace) against the whole repo. |
+| [`lint-renovate-config-check.yaml`](.github/workflows/lint-renovate-config-check.yaml) | Validate Renovate config file(s) with `renovate-config-validator`. |
+| [`lint-shellcheck.yaml`](.github/workflows/lint-shellcheck.yaml) | Lint shell scripts with `shellcheck`. |
+| [`lint-terraform.yaml`](.github/workflows/lint-terraform.yaml) | Run `terraform fmt -check`, `terraform validate`, and `tflint` across a set of Terraform directories. |
+| [`lint-yaml.yaml`](.github/workflows/lint-yaml.yaml) | Lint YAML with `yamllint`. |
+| [`lint-zizmor.yaml`](.github/workflows/lint-zizmor.yaml) | Audit GitHub Actions workflows for security issues with [`zizmor`](https://github.com/zizmorcore/zizmor). |
+| [`release-please.yaml`](.github/workflows/release-please.yaml) | Cut PR-batched releases (changelog + version + tag) with [`release-please`](https://github.com/googleapis/release-please), driven by conventional commits. |
+| [`release-semantic.yaml`](.github/workflows/release-semantic.yaml) | Cut immediate, commit-triggered releases with [`semantic-release`](https://github.com/semantic-release/semantic-release) — dry-run on PRs, real release on `workflow_dispatch`. |
+| [`renovate.yaml`](.github/workflows/renovate.yaml) | Run a self-hosted [Renovate](https://github.com/renovatebot/renovate) against a repository. |
+| [`update-aqua-checksums.yaml`](.github/workflows/update-aqua-checksums.yaml) | Recompute [`aqua`](https://aquaproj.github.io/) checksum lockfiles and push the result as a signed commit. |
+
+Each workflow's `inputs:`/`secrets:`/`outputs:` block in its YAML file is the authoritative interface —
+this table is a summary, not a substitute for reading the file you're about to call.
+
+See [DESIGN.md](DESIGN.md) for how these workflows are structured, how they test themselves
+(`self-*.yaml`), and how release/renovate automation fits together, and [CLAUDE.md](CLAUDE.md) for
+repo-specific guidance when working with Claude Code.
+
+## Usage
+
+Call a workflow from a consuming repo's own workflow file with `uses:`, pinned to a released tag or
+commit SHA:
+
+```yaml
+jobs:
+  lint-yaml:
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@v4.0.0
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}
+```
+
+For workflows that need a GitHub App token (`release-please.yaml`, `release-semantic.yaml`,
+`renovate.yaml`, `update-aqua-checksums.yaml`), pass `app_id`/`app_private_key` as secrets:
+
+```yaml
+jobs:
+  release:
+    uses: ppat/github-workflows/.github/workflows/release-please.yaml@v4.0.0
+    secrets:
+      app_id: ${{ secrets.HOMELAB_BOT_APP_ID }}
+      app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}
+```
+
+See `.github/workflows/self-*.yaml` in this repo for complete, working call sites of every workflow
+above.


### PR DESCRIPTION
Cross-references each other rather than duplicating content: README lists what each reusable workflow does, DESIGN.md explains conventions and how release-please/semantic-release/renovate/self-testing fit together, CLAUDE.md is repo-layout guidance for Claude Code sessions.