### PR TITLE
feat(renovate): allow mise unsafe execution for lockfile maintenance

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -58,6 +58,7 @@ jobs:
         renovate-version: "44.14.12"
       env:
         LOG_LEVEL: ${{ inputs.log_level }}
+        RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
         RENOVATE_DRY_RUN: "${{ inputs.dry_run && 'extract' || '' }}"
         RENOVATE_GIT_IGNORED_AUTHORS: "182250461+homelab-workflows-bot[bot]@users.noreply.github.com"
         # yamllint disable-line rule:indentation


### PR DESCRIPTION
Renovate's mise manager can refresh mise.lock via `mise lock --bump` (lockFileMaintenance), but treats it as an unsafe execution since mise lock can run repository-defined behavior. That's gated behind the self-hosted allowedUnsafeExecutions setting, which only takes effect via the RENOVATE_ALLOWED_UNSAFE_EXECUTIONS env var passed to the renovate CLI itself -- add it here so mise.lock refreshes actually run for any repo using this reusable workflow (e.g. ppat/dotfiles, which just migrated its CLI tool management from aqua to mise's aqua: backend + lockfile).