### PR TITLE
fix(github-actions): invoke release-please CLI directly, drop the release-please-action wrapper

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,15 +4,28 @@ name: release-please
 
 on:
   workflow_call:
+    inputs:
+      dry_run:
+        required: false
+        type: boolean
+      verbose:
+        required: false
+        type: boolean
     secrets:
       app_id:
         required: true
       app_private_key:
         required: true
 
+env:
+  # renovate: datasource=npm depName=release-please
+  RELEASE_PLEASE_VERSION: "17.11.1"
+  # renovate: datasource=node-version
+  NODE_VERSION: "24.11.1"
+
 jobs:
   release-please:
-    if: ${{ (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') }}
+    if: ${{ (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || inputs.dry_run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -24,17 +37,43 @@ jobs:
         private-key: ${{ secrets.app_private_key }}
         owner: ${{ github.repository_owner }}
 
-    - name: Release Please
-      uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-      id: release
+    - name: Setup repository and tools
+      uses: ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0
       with:
-        repo-url: ${{ github.repository }}
+        current_git_ref: ${{ github.ref }}
+        current_repository: ${{ github.repository }}
         token: ${{ steps.app-token.outputs.token }}
-        config-file: release-please-config.json
-        manifest-file: .release-please-manifest.json
+        mise_toml: |
+          [tools]
+          node                     = "${{ env.NODE_VERSION }}"
+          "npm:release-please"     = "${{ env.RELEASE_PLEASE_VERSION }}"
 
-    - name: Show Release Please Output
+    # release-please itself never reads the checked-out working tree - both
+    # the action and the CLI operate entirely over the GitHub API (config
+    # files are fetched via `github.getFileJson()` against `repo-url`), so
+    # `setup-repository-tools`' checkout above is only there to install
+    # tooling. `github-release` then `release-pr` matches the action's own
+    # call order (`manifest.createReleases()` then
+    # `manifest.createPullRequests()` in manifest mode, which this workflow
+    # uses since no `release-type` is set).
+    - name: Release Please
       env:
-        RELEASE_PLEASE_OUTPUT: ${{ toJSON(steps.release.outputs) }}
+        RELEASE_PLEASE_REPO_URL: ${{ github.repository }}
+        RELEASE_PLEASE_TOKEN: ${{ steps.app-token.outputs.token }}
+        RELEASE_PLEASE_DRY_RUN: "${{ inputs.dry_run && '--dry-run' || '' }}"
+        RELEASE_PLEASE_VERBOSE: "${{ inputs.verbose && '--debug' || '' }}"
+      # yamllint disable-line rule:indentation
       run: |
-        echo ${RELEASE_PLEASE_OUTPUT} | jq .
+        set -x
+        release-please github-release \
+          --repo-url="${RELEASE_PLEASE_REPO_URL}" \
+          --token="${RELEASE_PLEASE_TOKEN}" \
+          --config-file="release-please-config.json" \
+          --manifest-file=".release-please-manifest.json" \
+          ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}
+        release-please release-pr \
+          --repo-url="${RELEASE_PLEASE_REPO_URL}" \
+          --token="${RELEASE_PLEASE_TOKEN}" \
+          --config-file="release-please-config.json" \
+          --manifest-file=".release-please-manifest.json" \
+          ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}

--- a/.github/workflows/self-test-release-please.yaml
+++ b/.github/workflows/self-test-release-please.yaml
@@ -1,0 +1,30 @@
+---
+# yamllint disable rule:line-length
+name: self-test-release-please
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/release-please.yaml'
+    - '.github/workflows/self-test-release-please.yaml'
+    - 'release-please-config.json'
+    - '.release-please-manifest.json'
+  schedule:
+  - cron: '0 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-please.yaml
+    with:
+      dry_run: true
+      verbose: true
+    secrets:
+      app_id: ${{ secrets.HOMELAB_BOT_APP_ID }}
+      app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,14 +79,20 @@ This repo offers **two independent release mechanisms** as reusable workflows, b
 history, and both remain actively maintained here — this is a deliberate, unhurried mid-migration state, not
 an oversight:
 
-- `release-please.yaml` wraps
-  [`googleapis/release-please-action`](https://github.com/googleapis/release-please-action): PR-based —
-  commits land on a standing release PR that captures the pending changelog/version bump, and merging that
-  PR is what cuts the release. Signed commits are the default behavior, not a workaround. It also natively
-  supports monorepos, including both same-version-across-all-components and independently-versioned
-  components, which `semantic-release` has no real equivalent for. This repo releases **itself** this way —
-  `self-release-please.yaml` runs it on every push to `main`, driven by `release-please-config.json` /
-  `.release-please-manifest.json`.
+- `release-please.yaml` installs the [`release-please`](https://github.com/googleapis/release-please) CLI
+  itself via `setup-repository-tools` (mise, `npm:release-please`) and invokes `release-please github-release`
+  then `release-please release-pr` directly, rather than wrapping
+  [`googleapis/release-please-action`](https://github.com/googleapis/release-please-action) — the action's
+  own release cadence lagged badly enough behind `release-please` proper that it stayed pinned to a version
+  carrying a changelog bug (any recognized issue reference, regardless of footer keyword, rendered as
+  `, closes` and auto-closed the referenced issue on squash-merge; fixed upstream in `release-please` 17.10.4).
+  Both the CLI and the action are thin wrappers around the same `Manifest.fromManifest()` API calls, so
+  behavior is unchanged: PR-based — commits land on a standing release PR that captures the pending
+  changelog/version bump, and merging that PR is what cuts the release. Signed commits are the default
+  behavior, not a workaround. It also natively supports monorepos, including both
+  same-version-across-all-components and independently-versioned components, which `semantic-release` has no
+  real equivalent for. This repo releases **itself** this way — `self-release-please.yaml` runs it on every
+  push to `main`, driven by `release-please-config.json` / `.release-please-manifest.json`.
 - `release-semantic.yaml` wraps
   [`semantic-release`](https://github.com/semantic-release/semantic-release) (config in `.releaserc.js`,
   dependencies in `package.json`/`bun.lock`): commit-driven, releases immediately on `workflow_dispatch`

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -9,8 +9,8 @@ rules:
     # `github.repository`, but omit explicit `repositories:`/`permission-*`
     # inputs on `create-github-app-token`, so the token is broader than used.
     # Narrowing these is a follow-up, not required for the zizmor gate itself.
-    - release-please.yaml:20
-    - release-please.yaml:25
+    - release-please.yaml:33
+    - release-please.yaml:38
     - release-semantic.yaml:52
     - release-semantic.yaml:57
     - renovate.yaml:38


### PR DESCRIPTION
## Why

`googleapis/release-please-action` is pinned at `v5.0.0` (2026-04-22), which bundles `release-please` 17.6.0. That version's changelog generator hardcodes the literal text `, closes` for *any* commit footer it recognises as an issue reference, regardless of the footer's actual keyword — `Refs #N`, `Closes #N`, and `Fixes #N` all render as `closes #N` in the generated changelog, and GitHub auto-closes the referenced issue when the release PR carrying that text is squash-merged. Fixed upstream in [googleapis/release-please#2851](https://github.com/googleapis/release-please/pull/2851), first shipped in `release-please` **17.10.4** (2026-07-21) — but no release of the action bundles it:

- `v5.0.0` is still the newest tag (verified via `git ls-remote --tags`, exhaustively — no `v5.0.1`+ exists).
- The action's own auto-generated release PR ([`googleapis/release-please-action#1209`](https://github.com/googleapis/release-please-action/pull/1209), `chore(main): release 5.0.1`) has sat open and mergeable since 2026-05-27 (~3 months) and would only bump to `release-please` 17.6.1 anyway — still short of the fix.
- A separate Dependabot PR ([`#1222`](https://github.com/googleapis/release-please-action/pull/1222), bump to 17.11.1 — which *does* carry the fix) has sat open since 2026-08-03.

Given the action's demonstrated release cadence (recent gaps of 2–8.5 months between tags) and that it's currently stuck behind two of its own unmerged PRs, waiting on a new action release isn't attractive. This PR installs `release-please` directly via mise (this repo's existing pattern for npm-distributed CLI tools, e.g. `lint-renovate-config-check.yaml`'s `npm:renovate`) and invokes it as a CLI, replacing the action entirely.

## What this PR does

`release-please.yaml` now invokes the `release-please` CLI (pinned to **17.11.1**, at/above the 17.10.4 fix floor, tracked by Renovate via `# renovate: datasource=npm depName=release-please`) as the **sole** implementation:

- `googleapis/release-please-action` is gone from the workflow.
- The job installs `node` + `npm:release-please` via `setup-repository-tools` (same SHA/version — `v2.2.0` — already used by every other workflow in this repo) and runs `release-please github-release` then `release-please release-pr` against the real repo. No `continue-on-error`, no second implementation running alongside, no staged rollout.
- The `Show Release Please Output` step is removed. It echoed `steps.release.outputs` from the action for display only — the workflow declares no `outputs:` block and no consumer job read it (confirmed below). The CLI's own log (`set -x` plus its structured stdout) serves the same purpose without a step that has nothing left to read from.
- A `dry_run` `workflow_call` input (unset/`false` by default, same name/shape as `release-semantic.yaml`'s and `renovate.yaml`'s) appends `--dry-run` to both commands when `true`. It is **not** used on the real release path — `self-release-please.yaml` (push to `main` / `workflow_dispatch`) never sets it, so every real release still runs the exact two commands with no flag added. It exists solely so `self-test-release-please.yaml` (below) can exercise the real invocation without writing to GitHub.
- A `verbose` `workflow_call` input, same shape as `dry_run`, appends `--debug` to both commands when `true`. Also never set on the real release path. See "`verbose` / `--debug`" below for what it actually does (and doesn't do) in this release-please version, verified rather than assumed.

## Continuous verification — `self-test-release-please.yaml`

The first version of this PR ran a dry-run CLI step inline, next to the action, on every real release — rejected, correctly, for adding latency to an already-slow release path without ever executing the code that would eventually replace the action. The actual gap it was reaching for already has a house pattern this repo uses for the sibling release mechanism: `self-test-semantic-release.yaml` calls `release-semantic.yaml` with `dry_run: true` on `pull_request` (`paths`-filtered), a daily `schedule`, and `workflow_dispatch` — exercising the real reusable workflow against a throwaway (dry-run) target on every change, rather than only on real releases.

`self-test-release-please.yaml` is the same pattern applied to `release-please.yaml`: triggers on `pull_request` (paths: `.github/workflows/release-please.yaml`, `.github/workflows/self-test-release-please.yaml`, `release-please-config.json`, `.release-please-manifest.json`), the same daily `schedule`, and `workflow_dispatch`; same `concurrency` shape, `permissions: {}`, and `HOMELAB_BOT_APP_ID`/`HOMELAB_BOT_APP_PRIVATE_KEY` secrets wiring as `self-test-semantic-release.yaml`. It calls `release-please.yaml` with `dry_run: true`. No `show-` job: unlike `release-semantic.yaml`, `release-please.yaml` declares no job `outputs:` — the CLI prints everything relevant to its own step log — so there's nothing for a display job to read.

One consequence: `release-please.yaml`'s job previously ran only `if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')` — a guard that would have silently skipped the job when called from a `pull_request`- or `schedule`-triggered self-test (the caller's triggering event, not `workflow_call`, is what `github.event_name` evaluates to inside a called workflow). Extended it to `|| inputs.dry_run` so the self-test's `pull_request`/`schedule` runs aren't silently no-ops while real releases (which never set `dry_run`) are ungated by it.

**This ran for real, in this PR's own CI** — not just anticipated. `self-test-release-please.yaml`'s `pull_request` trigger matched this PR's `paths` (it touches `release-please.yaml` and itself), so `release / release-please` in `gh pr checks 601` is that self-test's actual first run, using the workflow's real GitHub App token and the real `ubuntu-24.04` runner (the local proof below used a personal token from a local shell — this is the thing that proof couldn't reach). Its log:

```
+ release-please github-release --repo-url=ppat/github-workflows --token=*** --config-file=... --manifest-file=... --dry-run --debug
❯ Fetching release-please-config.json from branch main
❯ Fetching .release-please-manifest.json from branch main
✔ Would tag 0 releases:
+ release-please release-pr --repo-url=ppat/github-workflows --token=*** --config-file=... --manifest-file=... --dry-run --debug
❯ Fetching release-please-config.json from branch main
❯ Fetching .release-please-manifest.json from branch main
Would open 1 pull requests
```

(That's `self-test-release-please.yaml` calling this workflow with both `dry_run: true` and `verbose: true` — confirms `--debug` genuinely reaches the real invocation, both flags compose on one command line, and — matching the local finding below — its presence changes nothing about the output next to the `--dry-run`-only run from the previous version of this PR.) CI's `zizmor`, `pre-commit`, `github-actions` (actionlint), `yaml`, and `markdown` gates all pass too — see `gh pr checks 601`.

## `verbose` / `--debug`

Established from `release-please`'s own source (`build/src/bin/release-please.js` at `v17.11.1`), not assumed:

- `--debug` and `--trace` are **global** yargs options — declared via `.option('debug', {...})` / `.option('trace', {...})` chained directly on the top-level `yargs` parser *after* all `.command()` registrations, not inside any command's own `builder()`. That means they're valid on every subcommand, `github-release` and `release-pr` included, and yargs doesn't care where in the argument list they appear — confirmed by running both flags trailing after `--manifest-file` in every local invocation below, with no "unknown argument" error.
- `--trace` implies `--debug` (its middleware branch is checked first) and additionally enables trace-level logging plus, in `release-pr --dry-run`'s output specifically, a unified diff of each file the release PR would change. `--debug` alone does neither of those extra things.
- Went with `--debug`, per instruction — not `--trace` — since `--trace`'s extra output (full file diffs) is more than "verbose," it's a second, heavier mode this workflow has no stated need for.

**What `--debug` actually does in this version — checked, not assumed, and the finding is not what the flag's own describe string implies:**

`--debug`'s only documented effect is in `handleError()`: if `argv.debug` is set, an otherwise-caught top-level error additionally logs `err.stack`. Everywhere else, the logger already runs at debug level *by default* — `util/logger.js` sets `exports.logger = new CheckpointLogger(true)` unconditionally at module load, and `--debug`'s middleware sets the exact same `CheckpointLogger(true)` — so on the success path, passing `--debug` changes nothing observable, flag or no flag.

On the error path, neither `github-release` nor `release-pr`'s handler wraps its body in a local `try`/`catch`, so a thrown error becomes an unhandled promise rejection. `handleError` is only registered as a `process.on('unhandledRejection', ...)` listener *after* `await exports.parser.parseAsync()` resolves — if the handler itself throws, that `await` throws first, before the listener is ever attached, so the error is caught by **Node's own default unhandled-rejection printer** instead, which dumps the complete error object (stack plus every enumerable property) regardless of `--debug`. `handleError`'s `--debug`-gated branch is therefore not reached by the error classes these two commands can actually raise.

Verified this empirically rather than trusting the code-reading: ran matched pairs, with and without `--debug`, for the success path and two distinct failure classes, against real API calls —

| Scenario | `diff` between with/without `--debug` |
|---|---|
| `github-release --dry-run`, real repo/token (success) | empty (byte-identical) |
| `release-pr --dry-run`, real repo/token (success) | empty (byte-identical) |
| `github-release --dry-run`, bad token + nonexistent repo (401 at client creation, `RequestError`) | empty except timestamp/request-id fields |
| `github-release --dry-run`, real repo/token, nonexistent `--manifest-file` (`ConfigurationError`, no HTTP layer involved) | **exactly identical**, 0-line diff |

So today, for these two commands, `--debug` is observably inert — a documented option that reaches the CLI correctly (proven: no parse error, appears in `--help`, and is genuinely part of `argv`) but changes nothing in either the success or the two failure shapes tested. This is the "obvious failure" worth naming plainly rather than glossing over: wiring `verbose: true` on the self-test proves the flag threads through the workflow, but it can't prove the flag *does* anything, because on this version it doesn't. Wiring it anyway per instruction, since being inert isn't the same as being wrong to add — see below on why it's not a live risk either — and because upstream could change this in a future release-please version without this workflow needing to change.

**On the "use only for local debugging" caution** — real, but not for the reason the describe string implies, and not one this specific wiring reintroduces: the actual risk named in `release-please`'s own source comment (`bin/release-please.js`, above `handleError`) is *"the errors returned by octokit currently contain the request object, this contains information we don't want to leak... run with --debug to output the request object, don't do this in CI/CD."* Went looking for what that request object actually contains by triggering a real `401` (bad token, nonexistent repo) and inspecting the raw dump: `request.headers.authorization` printed as the literal string `'token [REDACTED]'` — octokit's own `RequestError` redacts the bearer token before attaching the request object to the error, in *every* case, `--debug` or not. The full URL, non-auth response headers, and response body **are** included in that dump (repo name, GitHub's rate-limit headers, etc.) — not secret material for this repo, but worth knowing exists. Because (per the finding above) this full dump happens via Node's default printer regardless of `--debug` for the errors these commands can raise, `--debug` isn't adding a new exposure path here — the same information would print on an unhandled error either way. Concluded there's nothing in this specific case to stop for, but flagging it explicitly rather than silently deciding it's fine: worth a second look if `release-please` restructures its error handling in a future version such that `--debug` starts controlling something that currently happens unconditionally.

## Mapping the action's inputs to CLI flags

The action (`src/index.ts` at the pinned SHA) is confirmed to be a thin wrapper: with no `release-type` input set (our case — this repo uses manifest mode), it calls `Manifest.fromManifest(github, defaultBranch, inputs.configFile, inputs.manifestFile, manifestOverrides)`, then `manifest.createReleases()` and `manifest.createPullRequests()`.

The CLI's `release-please` bin (`src/bin/release-please.ts`) has two non-deprecated commands that do the exact same thing when no `--release-type` is passed — used here instead of the older `manifest-pr`/`manifest-release` commands, which are marked `deprecated` in the CLI's own source and log a deprecation warning:

| Action behavior | CLI command | Notes |
|---|---|---|
| `manifest.createReleases()` (`skip-github-release` not set) | `release-please github-release` | Handler calls the identical `Manifest.fromManifest(github, targetBranch, argv.configFile, argv.manifestFile, manifestOptions)` when `argv.releaseType` is unset |
| `manifest.createPullRequests()` (`skip-github-pull-request` not set) | `release-please release-pr` | Same `Manifest.fromManifest` call path, matching the action's manifest-mode branch |

The workflow calls them in that order (`github-release` then `release-pr`), matching the action's own `createReleases()` → `createPullRequests()` sequence.

Flag mapping, both commands:

| Action input (`with:`) | CLI flag | Notes |
|---|---|---|
| `repo-url: ${{ github.repository }}` | `--repo-url` | Confirmed `parse-github-repo-url` (used by `buildGitHub()`) accepts the bare `owner/repo` shorthand, same format the action already receives |
| `token: ${{ steps.app-token.outputs.token }}` | `--token` | Passed via `env:` + shell variable expansion, not inlined into the command text. Checked `coerceOption()` (`src/util/coerce-option.ts`): it only treats a `--token` value as a file path if it contains a slash or backslash; GitHub App installation tokens (`ghs_...`) don't, so the raw token is used as a literal, same as the action |
| `config-file: release-please-config.json` | `--config-file` | Identical default and semantics |
| `manifest-file: .release-please-manifest.json` | `--manifest-file` | Identical default and semantics |
| *(not set — action default)* `fork`, `skip-labeling`, `versioning-strategy`, `include-component-in-tag`, `target-branch`, etc. | *(not set — CLI default)* | Verified the CLI's yargs defaults match the action's declared `action.yml` defaults for every input this workflow doesn't already override, so omitting them keeps behavior identical rather than silently changing it |

Both the action and the CLI fetch `release-please-config.json`/`.release-please-manifest.json` via the GitHub API (`github.getFileJson()` in `src/manifest.ts`), not from a local checkout — confirmed by the fact the *existing* workflow (before this PR) never ran `actions/checkout` at all. `setup-repository-tools` still checks the repo into `current/` (an unconditional part of that action), but nothing in this workflow reads it — release-please doesn't need it either way.

**This is not "nothing else changed" — three things are worth stating plainly rather than folded into a blanket equivalence claim:**

- **Outputs.** The action sets roughly ten step outputs (`release_created`, `tag_name`, `upload_url`, per-path variants, etc.). The CLI has no equivalent — nothing here reads them, since (confirmed above, in "Blast radius" below) the workflow declares no `outputs:` block and no consumer job depends on `jobs.release-please.outputs`. This is a real behavioral difference, just one with no observer.
- **Defaults are pinned, not inherited.** The action calls `extractManifestOptions()`, which lets yargs fill in unset flags from the library's *current* defaults before calling the same `Manifest.fromManifest`. The CLI does the same thing at invocation time, but because this workflow's `run:` step spells out the flags rather than delegating to the action's input-forwarding, verifying "the CLI's defaults match the action's `action.yml` defaults" (previous section) is a snapshot, not a standing guarantee: e.g. `fork: false`, `labels: ['autorelease: pending']`, `skipLabeling: false`, `draftPullRequest: false` (both commands) and `releaseLabel`/`snapshotLabel`/`draft: false` (`github-release` only) are what the *current* release-please library defaults to. They produce identical behavior today. If a future release-please version changes one of those library defaults, the action would pick it up automatically (it always calls yargs' current defaults) and this workflow would not, since nothing here pins those flags explicitly — the equivalence holds now, not permanently, and re-verifying it isn't automatic the way a version bump is.
- **The action logs its own bundled version** on every run; the CLI doesn't announce a version by default (visible in the local proof below only via `release-please --version` run separately, not as part of `github-release`/`release-pr` output).

## mise / tool installation

- `ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0` — matches the SHA/version every other workflow in this repo already uses (`chainsaw-test.yaml`, `lint-renovate-config-check.yaml`, etc.); the version this workflow previously carried in review (`v2.1.0`) was the odd one out.
- `"npm:release-please" = "17.11.1"` — mise's npm backend, confirmed against [its docs](https://mise.jdx.dev/dev-tools/backends/npm.html): pin syntax is `"npm:<pkg>" = "<version>"` in `[tools]`, installs directly from the npm registry without needing a package manager CLI. `# renovate: datasource=npm depName=release-please` tracks it, matching this repo's existing custom-manager convention (see `.github/renovate.json`'s `matchStrings` for that comment format).
- `node = "24.11.1"` — **added, not present in the action-based version of this workflow.** `release-please`'s own `package.json` declares `"engines": {"node": ">=22.0.0"}`. Checked mise's npm-backend docs explicitly on this: *"the npm backend does not add or install `node` automatically"* — a package needing a specific Node version must list `node` as its own `[tools]` entry, exactly the pattern `lint-renovate-config-check.yaml` already uses for `bun`+`node`+`npm:renovate` in this same repo. `24.11.1` is what every other workflow in this repo already pins `NODE_VERSION` to, comfortably above the `>=22.0.0` floor.
- Verified `release-please`'s `package.json` and `src/bin/release-please.ts` are byte-identical between the `main` branch and the `v17.11.1` tag, so everything above checked against `main` also holds at the pinned version.

## What I verified vs. what I could not

**Verified directly against source** (`googleapis/release-please` and `release-please-action` at the pinned/tagged refs, not from memory): the action's wrapper behavior, the CLI's flag surface and defaults, the token-as-file-path edge case, the API-driven (not checkout-driven) config loading, and that `main`/`v17.11.1` are identical for the files this depends on. Also read `--debug`'s and `--trace`'s full option registration and `handleError`'s branching directly, not summarized secondhand — see "`verbose` / `--debug`" above.

**Verified by executing the exact CLI invocation locally**, rather than staging a dry-run inside the workflow: installed `release-please@17.11.1` via mise using the same `mise_toml` this workflow now uses, then ran, against the real `ppat/github-workflows` repository (own `gh auth token`, not the app token this workflow uses, but the same API surface):

```
release-please github-release --repo-url=ppat/github-workflows --token=*** \
  --config-file=release-please-config.json --manifest-file=.release-please-manifest.json --dry-run
→ Fetched release-please-config.json / .release-please-manifest.json from branch main over the API
→ Would tag 0 releases   (exit 0 — correct: no release PR is currently pending merge)

release-please release-pr --repo-url=ppat/github-workflows --token=*** \
  --config-file=release-please-config.json --manifest-file=.release-please-manifest.json --dry-run
→ Fetched config/manifest over the API, walked commits since v4.4.0, built the candidate release PR
→ Would open 1 pull requests: "chore(release): release v4.5.0" with a correctly formatted changelog body
  (exit 0)
```

This confirms the command names, the flag surface, config/manifest loading over the API, and the tool install all work end to end against this repo's real state — the things a typo or wrong assumption would break — without adding a dry-run step to the release path itself. `--dry-run` was only ever passed explicitly by hand for this one-time local proof.

Also verified the `${RELEASE_PLEASE_DRY_RUN}` flag-append mechanism itself, both branches, with `set -x` tracing the literal argv: with the var set to `--dry-run`, the command line ends in `... --manifest-file=.release-please-manifest.json --dry-run`; with it unset/empty, the trace shows the command line ending at `--manifest-file=.release-please-manifest.json` with no trailing empty argument (bash performs word-splitting on an unquoted empty expansion, producing zero words, not an empty-string arg) — confirmed this is why the shellcheck `SC2086` finding `actionlint` raises here is expected and already suppressed repo-wide via `.shellcheckrc` (`disable=SC2086`), matching how `lint-github-actions.yaml`'s CI step invokes `actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"`.

**Could not verify locally**: a real (non-dry-run) `github-release`/`release-pr` invocation, since that would create real GitHub state — the local proof above is dry-run only, by construction, to avoid side effects from a machine that isn't the workflow's own GitHub App identity. The first real run of `self-release-please.yaml` after this merges is the first execution using the actual app token and actual `PATH` inside `ubuntu-24.04` — that environment (composite action install, cache behavior) is not something a local shell reproduces exactly, though the tool version, flags, and API calls are now identical to what was proven above.

## Blast radius

This is a reusable workflow; a defect propagates to every caller's release process. Confirmed consumers of `ppat/github-workflows/.github/workflows/release-please.yaml` (searched all of `ppat`'s repos, public and private, for `uses:` references):

- `ppat/homelab-ops-kubernetes-apps`
- `ppat/obsidian-tools`
- `ppat/homelab-ops-actions`
- `ppat/renovate-presets`
- `ppat/validate-kubernetes-manifests`

All five currently pin `github-workflows@v4.4.0` (verified: that tag's `release-please.yaml` still points at the same broken `release-please-action@v5.0.0` SHA as `main`), so none of them are affected until they bump their ref past whatever tag this ships in.

**Inversion — what would make this fail silently rather than loudly:** the failure mode a consumer would actually see is "no release PR appeared", with nothing paging anyone. Concretely: a tool that installs but isn't on `PATH` (mise's npm backend needing `node` listed explicitly is exactly this class of failure, which is why it's pinned above), a token with insufficient permissions causing the CLI to no-op rather than error, or a `release-please` exit code that's 0 despite doing nothing (both dry-run proofs above returned useful, non-empty state, which is some evidence against a systematically-silent no-op, but doesn't rule out an auth-scoped variant only reachable with the real app token). Nothing here adds alerting for that mode — noted as a known gap, not solved by this PR.

**Outputs**: `release-please.yaml`'s `workflow_call` trigger declares no `outputs:` block and the job declares none either. All five consumers' `release.yaml` were read in full: each has exactly one job, and none has a downstream job depending on `jobs.release.outputs`. Nothing outside this workflow could see or depend on the removed `Show Release Please Output` step.

## Interim mitigation worth recording (not built here — out of scope for this repo)

Read `release-please`'s own commit-footer parser (`src/commit.ts`) while investigating this. A footer only becomes a "reference" fed into the buggy changelog template if it contains a literal `#` **and** the referenced token is purely numeric:

```ts
const NUMBER_REGEX = /^[0-9]+$/;
...
if (hasRefSepartor && reference.issue.match(NUMBER_REGEX)) {
  headerCommit.references.push(reference);
}
```

A footer written as a full URL — e.g. `Refs: https://github.com/ppat/homelab-ops-kubernetes-apps/issues/3611` instead of `Refs #3611` — never matches either condition, so it never reaches the hardcoded `, closes` template at all. This defeats the bug **today, against any currently-deployed `release-please-action` version anywhere**, generalizes to any long-lived tracking issue, and leaves ordinary `Closes #123` working for issues that should legitimately auto-close. It's convention-only and can't be mechanically enforced without hardcoding a specific issue number into commitlint — already tried and rejected. Recording it here since it's the fastest available mitigation for consumers still pinned below wherever this fix ships — but it belongs as a commit-convention change in `homelab-ops-kubernetes-apps` (or wherever this org documents cross-repo commit conventions), not in this repo, so it isn't part of this change.

## Epic

Refs [ppat/homelab-ops-kubernetes-apps#3611](https://github.com/ppat/homelab-ops-kubernetes-apps/issues/3611)
