### PR TITLE
feat(github-actions): parameterize zizmor thresholds, persona and advisory mode

### DIFF
--- a/.github/workflows/lint-zizmor.yaml
+++ b/.github/workflows/lint-zizmor.yaml
@@ -8,6 +8,21 @@ on:
       git_ref:
         required: true
         type: string
+      advisory_only:
+        description: 'Report findings but do not fail the job. Turns this gate off as a merge blocker; misconfiguration and tool errors still fail.'
+        required: false
+        type: boolean
+        default: false
+      min_confidence:
+        description: 'Lowest confidence level to report. One of: low, medium, high.'
+        required: false
+        type: string
+        default: 'high'
+      min_severity:
+        description: 'Lowest severity level to report. One of: informational, low, medium, high.'
+        required: false
+        type: string
+        default: 'medium'
       mise_ignore_cfg:
         required: false
         type: string
@@ -16,6 +31,11 @@ on:
         required: false
         type: string
         default: "warn"
+      persona:
+        description: 'How aggressively to audit. One of: regular (minimal false positives), pedantic (code smells too), auditor (false positives OK).'
+        required: false
+        type: string
+        default: 'regular'
 
 env:
   # renovate: datasource=github-releases depName=zizmorcore/zizmor
@@ -40,8 +60,18 @@ jobs:
 
     - name: Audit github actions with zizmor
       env:
+        ADVISORY_ONLY: ${{ inputs.advisory_only }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MIN_CONFIDENCE: ${{ inputs.min_confidence }}
+        MIN_SEVERITY: ${{ inputs.min_severity }}
+        PERSONA: ${{ inputs.persona }}
       shell: bash
       working-directory: ./current
+      # yamllint disable-line rule:indentation
       run: |
-        zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .
+        ZIZMOR_ARGS=( --format=github "--min-severity=${MIN_SEVERITY}" "--min-confidence=${MIN_CONFIDENCE}" "--persona=${PERSONA}" )
+        if [[ "${ADVISORY_ONLY}" == "true" ]]; then
+          echo "::warning::zizmor is running in advisory_only mode - findings below are reported but will NOT fail this job"
+          ZIZMOR_ARGS+=( --no-exit-codes )
+        fi
+        zizmor "${ZIZMOR_ARGS[@]}" .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ releases, and dependency updates.
 | [`lint-shellcheck.yaml`](.github/workflows/lint-shellcheck.yaml) | Lint shell scripts with `shellcheck`. |
 | [`lint-terraform.yaml`](.github/workflows/lint-terraform.yaml) | Run `terraform fmt -check`, `terraform validate`, and `tflint` across a set of Terraform directories. |
 | [`lint-yaml.yaml`](.github/workflows/lint-yaml.yaml) | Lint YAML with `yamllint`. |
-| [`lint-zizmor.yaml`](.github/workflows/lint-zizmor.yaml) | Audit GitHub Actions workflows for security issues with [`zizmor`](https://github.com/zizmorcore/zizmor). |
+| [`lint-zizmor.yaml`](.github/workflows/lint-zizmor.yaml) | Audit GitHub Actions workflows for security issues with [`zizmor`](https://github.com/zizmorcore/zizmor). `min_severity`/`min_confidence`/`persona` inputs tune what gets reported (defaulting to the org-wide `medium`/`high`/`regular`); `advisory_only: true` reports findings without failing the job. |
 | [`release-please.yaml`](.github/workflows/release-please.yaml) | Cut PR-batched releases (changelog + version + tag) with [`release-please`](https://github.com/googleapis/release-please), driven by conventional commits. |
 | [`release-semantic.yaml`](.github/workflows/release-semantic.yaml) | Cut immediate, commit-triggered releases with [`semantic-release`](https://github.com/semantic-release/semantic-release) — dry-run on PRs, real release on `workflow_dispatch`. |
 | [`renovate.yaml`](.github/workflows/renovate.yaml) | Run a self-hosted [Renovate](https://github.com/renovatebot/renovate) against a repository. |


### PR DESCRIPTION
## What

Turns the four hardcoded `zizmor` flags in `lint-zizmor.yaml` into `workflow_call` inputs, plus an
explicit advisory (non-blocking) mode. Nothing else about the workflow changes.

Verified against the real `zizmor` CLI at the version this workflow pins (`v1.29.0`), not from memory —
`--persona`, `--min-severity`, `--min-confidence`, `--no-exit-codes` all confirmed present with the
value sets documented below.

## Inputs → defaults → current-behavior equivalence

| Input | Type | Default | Maps to | Equivalence with today |
| --- | --- | --- | --- | --- |
| `min_severity` | string | `medium` | `--min-severity=<v>` | Identical — `--min-severity=medium` is the current hardcoded value |
| `min_confidence` | string | `high` | `--min-confidence=<v>` | Identical — `--min-confidence=high` is the current hardcoded value |
| `persona` | string | `regular` | `--persona=<v>` | Identical — `--persona=regular` is the current hardcoded value |
| `advisory_only` | boolean | `false` | `--no-exit-codes` (only when `true`) | Identical — flag is not emitted at the default, and the `::warning::` line is not printed either |

Valid values (enforced by zizmor's own arg parser, see "Input validation" below):

- `min_severity`: `informational`, `low`, `medium`, `high`
- `min_confidence`: `low`, `medium`, `high`
- `persona`: `regular`, `pedantic`, `auditor`

## Backward-compatibility proof

The `run:` block was extracted verbatim and executed against a stub `zizmor` that echoes its argv, with
all inputs at their defaults (i.e. a caller passing only `git_ref`):

```
BEFORE (hardcoded on main):
  zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .

AFTER (all inputs at defaults):
  zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .

RESULT: IDENTICAL (byte-for-byte)
```

Same flag set, same flag order, same trailing `.`. At the default the `if [[ "${ADVISORY_ONLY}" == "true" ]]`
branch is not taken, so there is no extra log output either.

Exit-code semantics were also confirmed empirically against `zizmor v1.29.0`:

| Scenario | Exit code |
| --- | --- |
| Findings present, default (blocking) | `13` |
| Findings present, `advisory_only: true` | `0` |
| No findings | `0` |
| Invalid flag value, even with `--no-exit-codes` | `2` |

That last row is the important one: `advisory_only` suppresses *findings* failing the job, but it does
**not** mask a misconfigured input or a tool failure.

## Consumers are unaffected and need no changes

A code search across the org finds 11 call sites, every one pinned to
`@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0` and every one passing only `git_ref`:

`homelab-ops-kubernetes-apps`, `homelab-ops-kubernetes-clusters`, `homelab-ops-kubernetes-experiments`,
`coder`, `homelab-ops-terraform`, `homelab-ops-pi`, `homelab-ops-actions`, `renovate-presets`,
`validate-kubernetes-manifests`, `obsidian-tools`, `garage-falsification-harness`
(plus `dotfiles`, whose zizmor job is still on an open PR).

Every new input is `required: false` with a default equal to the value it replaced, so **no consumer
needs any change**, and none will observe any difference when they eventually pick up a Renovate bump of
their pinned SHA. This is a `feat:` (minor) bump — purely additive.

## Why each input earned its place

- **`min_severity` / `min_confidence`** — the two threshold dials. Concretely: a repo doing a tightening
  pass (`min_confidence: medium` to surface more) or a low-stakes repo that only wants `high` severity
  noise. These are the knobs you actually reach for, and today the only way to change them is to fork the
  workflow.
- **`persona`** — the "operationalize" knob named in the ask. `pedantic` surfaces code smells,
  `auditor` accepts false positives for a deliberate audit sweep. A repo that has cleaned up its
  `regular` findings can ratchet to `pedantic` without touching this repo.
- **`advisory_only`** — the way to *try* any of the above before enforcing it. Deliberately named so
  that a reader of a consumer's `lint.yaml` sees the gate is non-blocking at a glance, rather than
  inferring it from a format or exit-code flag. It additionally emits a `::warning::` annotation in the
  job log so a run that isn't gating says so on its own.

## `ZIZMOR_VERSION`: deliberately NOT exposed

`ZIZMOR_VERSION` stays a Renovate-tracked workflow `env:` value. This isn't a close call — `DESIGN.md`
already has a section titled *"Tool versions are centralized, not overridden by consumers"* that states
no reusable workflow exposes a tool-version input, and explains why: one Renovate PR here bumps the
version for every consumer, and consumers pick it up through their own Renovate-tracked pinned SHA.
Exposing it as an input would let repos drift onto different zizmor versions with different audit sets,
which is precisely the failure mode central pinning exists to prevent.

Consumers that genuinely need a different version already have a supported escape hatch that requires no
workflow input at all: commit a `mise.toml` pinning `aqua:zizmorcore/zizmor`, which `mise` merges over
the workflow's inline `mise_toml:` (also documented in `DESIGN.md`).

## Deliberately NOT exposed

| Considered | Why not |
| --- | --- |
| `--format` | The only sensible value in CI is `github` (that's what produces PR annotations). `plain`/`json` would just make the log worse; `sarif` without an upload step (see below) dumps unreadable JSON into the log while still failing the build. No repo would set this. |
| audit target / paths | zizmor collects the whole tree by design, `.gitignore`-aware. None of the consuming repos vendor third-party workflows, so there is no concrete case for narrowing — and where one appears, `zizmor.yml` ignore rules are the right tool because they're self-documenting and per-finding. |
| `--config` / config file path | zizmor auto-discovers `zizmor.yml` / `zizmor.yaml` at the repo root (confirmed: this repo's own `zizmor.yaml` suppressions are honored with no `--config` flag). A repo needing custom config commits that file — an input would be a second, redundant way to do the same thing. |
| `--offline` / `--no-online-audits` | Would silently *disable audit rules* while the job still reports green. That's the "weaken the gate invisibly" category. All consumers run in Actions with a `GITHUB_TOKEN` available, so online audits work everywhere today. |
| `--no-ignores` | Inverse problem: no repo wants to ignore its own `zizmor.yaml` on a per-call basis. |
| `--fix` | Marked EXPERIMENTAL upstream, and a lint gate should not be mutating the tree. |
| `--no-progress`, `--color`, `--render-links`, `--show-audit-urls`, `-v/-q` | Output cosmetics only. |
| `runs-on`, `timeout-minutes` | Real variables, but they're workflow-infrastructure constants shared by all 18 workflows in this repo, none of which parameterize them. Making them inputs is a repo-wide convention decision, not a zizmor one — out of scope here. |

## Input validation: deliberately none

`workflow_call` has no `choice` type, so these are `type: string`. I did **not** add an upfront
validation step, because zizmor's own arg parser already fails fast with a message that is strictly
better than anything a hand-rolled check would print:

```
$ zizmor --min-severity=moderate .
error: invalid value 'moderate' for '--min-severity <LEVEL>'
  [possible values: informational, low, medium, high]
```

It names the input, the bad value, and every valid value. A bash pre-check would duplicate that list in
a second place that can drift when zizmor adds a level. The valid values are also documented in each
input's `description:`, which GitHub renders in the workflow UI.

## Follow-up recommendation: SARIF → GitHub code scanning

Recommended, but **as a separate PR**, not bundled here. `--format=sarif` piped to
`github/codeql-action/upload-sarif` would put findings in the Security tab with history and a dismissal
workflow instead of only failing a PR — that's the real "operationalize" step beyond thresholds. It's out
of scope for this PR because it is not strictly additive:

1. It needs `security-events: write`. Reusable workflows inherit the *caller's* permissions, so this
   would break for every consumer whose calling workflow sets `permissions: contents: read` — which is
   exactly what `self-lint.yaml` and the consumer `lint.yaml` files do today. Consumers would have to
   change, violating the "no consumer changes" property of this PR.
2. Code scanning upload requires GitHub Advanced Security on private repos.
3. It changes what "the zizmor job passed" means, since the natural pairing is uploading *all* findings
   (`--min-severity=informational`) while the blocking gate stays at `medium`/`high` — i.e. two zizmor
   invocations, not one.

None of that is hard, but it deserves its own PR with its own consumer-rollout story.

## Verification

- `actionlint -shellcheck "shellcheck --rcfile .shellcheckrc" .github/workflows/lint-zizmor.yaml` — clean
- `yamllint -c .yamllint --strict` — clean (file and whole repo)
- `zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .` (i.e. the
  workflow auditing itself) — `No findings to report. Good job!`
- `pre-commit run --all-files` — all hooks pass
- Backward-compat argv diff — identical, shown above
- `self-lint.yaml`'s `zizmor` job on this PR exercises the default path end-to-end
