### PR TITLE
fix(github-actions): select shell scripts by shebang, and check them one at a time

### DIFF
--- a/.github/workflows/lint-shellcheck.yaml
+++ b/.github/workflows/lint-shellcheck.yaml
@@ -49,12 +49,61 @@ jobs:
       working-directory: ./current
       # yamllint disable-line rule:indentation
       run: |
+        shellcheck_files=()
+
         if [[ "${SHELLSCRIPT_FILES}" == "ALL" ]]; then
-          set -x
-          find . -type f -not -path './node_modules/*' -not -path './.git/*' -not -path ./bun.lock -executable -exec shellcheck --rcfile .shellcheckrc {} +
-          set +x
+          # The executable bit alone does not mean "shell script": executable python/node
+          # scripts carry it too, and get rejected outright with SC1071. So keep only the
+          # files that declare themselves shell -- either a shebang naming one of the
+          # supported shells (sh/bash/dash/ksh), or a .sh/.bash extension. A file that
+          # declares neither cannot be linted anyway, since no dialect can be inferred for
+          # it (SC2148); the check-executables-have-shebangs pre-commit hook is what keeps
+          # shebang-less executables from being committed in the first place.
+          while IFS= read -r -d '' file; do
+            case "${file}" in
+              *.sh | *.bash)
+                shellcheck_files+=("${file}")
+                continue
+                ;;
+            esac
+            read -r first_line < "${file}" || true
+            if [[ "${first_line}" =~ ^#!.*[\ /](sh|bash|dash|ksh)([[:space:]]|$) ]]; then
+              shellcheck_files+=("${file}")
+            fi
+          done < <(find . -type f -not -path './node_modules/*' -not -path './.git/*' -not -path ./bun.lock -executable -print0)
         else
-          set -x
-          shellcheck --rcfile .shellcheckrc $SHELLSCRIPT_FILES
-          set +x
+          # An explicit caller-supplied list: the caller already decided what counts as a
+          # shell script here, so pass it through unfiltered rather than second-guessing
+          # it. Consumers legitimately list sourced fragments that have no shebang at all.
+          # Deliberate word splitting: the caller delimits its list with whitespace.
+          # shellcheck disable=SC2206
+          shellcheck_files=(${SHELLSCRIPT_FILES})
+        fi
+
+        if [[ "${#shellcheck_files[@]}" -eq 0 ]]; then
+          echo "shellcheck: no shell scripts selected -- nothing was checked"
+          exit 0
+        fi
+
+        # One invocation per file, each with its own PASS/FAIL line, so the log says what
+        # was checked instead of only what was wrong. A silent run and a run that checked
+        # nothing are no longer indistinguishable. Findings are printed under the FAIL line
+        # of the file they belong to, and every file is checked before the job gives up, so
+        # one bad script does not hide the rest.
+        failed=0
+        for file in "${shellcheck_files[@]}"; do
+          if output=$(shellcheck --rcfile .shellcheckrc "${file}" 2>&1); then
+            printf 'PASS  %s\n' "${file}"
+          else
+            printf 'FAIL  %s\n' "${file}"
+            printf '%s\n' "${output}"
+            failed=$((failed + 1))
+          fi
+        done
+
+        echo
+        echo "shellcheck: ${#shellcheck_files[@]} file(s) checked, ${failed} failed"
+
+        if [[ "${failed}" -gt 0 ]]; then
+          exit 1
         fi

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ releases, and dependency updates.
 | [`lint-markdown.yaml`](.github/workflows/lint-markdown.yaml) | Lint Markdown with `markdownlint-cli2`. |
 | [`lint-pre-commit.yaml`](.github/workflows/lint-pre-commit.yaml) | Run a fixed set of generic `pre-commit-hooks` (large files, shebangs, JSON, private keys, EOF, line endings, whitespace) against the whole repo. |
 | [`lint-renovate-config-check.yaml`](.github/workflows/lint-renovate-config-check.yaml) | Validate Renovate config file(s) with `renovate-config-validator`. |
-| [`lint-shellcheck.yaml`](.github/workflows/lint-shellcheck.yaml) | Lint shell scripts with `shellcheck`. |
+| [`lint-shellcheck.yaml`](.github/workflows/lint-shellcheck.yaml) | Lint shell scripts with `shellcheck`. With `files: ALL` it lints every executable file that identifies itself as shell, by shebang (`sh`/`bash`/`dash`/`ksh`) or by a `.sh`/`.bash` extension; otherwise it lints exactly the caller-supplied file list. |
 | [`lint-terraform.yaml`](.github/workflows/lint-terraform.yaml) | Run `terraform fmt -check`, `terraform validate`, and `tflint` across a set of Terraform directories. |
 | [`lint-yaml.yaml`](.github/workflows/lint-yaml.yaml) | Lint YAML with `yamllint`. |
 | [`lint-zizmor.yaml`](.github/workflows/lint-zizmor.yaml) | Audit GitHub Actions workflows for security issues with [`zizmor`](https://github.com/zizmorcore/zizmor). `min_severity`/`min_confidence`/`persona` inputs tune what gets reported (defaulting to the org-wide `medium`/`high`/`regular`); `advisory_only: true` reports findings without failing the job. |

--- a/test/shellcheck/extensionless-script
+++ b/test/shellcheck/extensionless-script
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Sample shell script with no file extension, for testing lint-shellcheck.
+# The selector must still lint this one -- it is identified by its shebang,
+# not by its name.
+echo "Sample script for testing lint-shellcheck..."

--- a/test/shellcheck/not-a-shell-script.py
+++ b/test/shellcheck/not-a-shell-script.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Executable non-shell script for testing lint-shellcheck.
+
+The selector must skip this. Handing it to shellcheck fails with SC1071
+("ShellCheck only supports sh/bash/dash/ksh"), which is what an executable-bit
+-only file selector used to do.
+"""
+
+print("Sample script for testing lint-shellcheck...")


### PR DESCRIPTION
## Root cause

`lint-shellcheck.yaml`'s `files: ALL` branch used the executable bit as a proxy for "is a shell script":

```bash
find . -type f -not -path './node_modules/*' -not -path './.git/*' -not -path ./bun.lock -executable \
  -exec shellcheck --rcfile .shellcheckrc {} +
```

Executable python/node scripts carry that bit too. They get handed to `shellcheck`, which refuses them
outright with `SC1071 (error): ShellCheck only supports sh/bash/dash/ksh/'busybox sh' scripts` and fails
the job. `-executable` is the *easy* proxy for "shell script"; it is not the predicate we actually need.

This is pre-existing and **progressive**, not a new regression — every executable non-shell script added
to any consumer repo makes it worse. Since consumers run `lint` on `pull_request` and a weekly
`schedule`, it has been surfacing on Mondays and staying ignorable.

**Two repos are red on `main` right now for exactly this reason**, plus two more:

| Repo | Non-shell files caught by `-executable` |
| --- | --- |
| `homelab-ops-kubernetes-clusters` | 4 × `.py` |
| `garage-falsification-harness` | 12 × `.py` |
| `images` | 1 × `.py` |
| `dependency-migrator` | 1 × `.mjs` (node) |

## Why the fix is at this layer

The selector is not in any consumer repo — `clusters`' `shellcheck` job is a one-line call to this
reusable workflow, and `ppat/homelab-ops-actions` (`setup-repository-tools`) only installs the pinned
`shellcheck` binary and contributes nothing to file selection. The `find` lives here, in
`.github/workflows/lint-shellcheck.yaml`, so fixing it here fixes it once for every consumer instead of
leaving the same landmine in fifteen other repos.

## The fix

Replace the proxy with the predicate it was standing in for: a file is linted when it **declares itself
shell** — a shebang naming a supported shell (`sh`/`bash`/`dash`/`ksh`), or a `.sh`/`.bash` extension.
Extension is deliberately not the primary test, because many of these scripts have no extension at all
(that is why `-executable` was reached for in the first place).

Unchanged: the traversal, its exclusions (`node_modules`, `.git`, `bun.lock`), and `--rcfile .shellcheckrc`.

### Why not `shellcheck -e SC1071`?

It does work — `shellcheck -e SC1071 script.py` exits 0. It was rejected because it suppresses the
*symptom*: a genuine shell script that someone gives a wrong shebang would then be silently skipped
instead of loudly reported. `shellcheck` 0.11.0 (the pinned version) offers no supported "skip files with
unsupported shebangs" flag — `--help` lists nothing of the sort, and `-S warning` does not help because
SC1071 is an error. Selecting the right files beats silencing the complaint about the wrong ones.

### Only the `ALL` branch is changed — deliberately

The other branch receives an **explicit, caller-supplied file list**. The caller has already decided what
counts as a shell script; filtering it would silently drop files the caller asked for. `dotfiles` proves
this concretely — 6 of the 11 files its `shellscripts` glob selects have **no shebang at all**:

```
private_dot_local/bash/aliases.bash             # Bash aliases
private_dot_local/bash/limits.bash              # The Coder workspace memory watchdog ...
private_dot_local/bash/shell-completions.bash   # Load shell completions
private_dot_local/bash/unset-env.bash           unset KUBERNETES_PORT_443_TCP_ADDR
dot_bashrc                                      # .bashrc
dot_profile                                     # shellcheck shell=bash
```

`shellcheck` lints all of these fine today via extension/filename/directive inference. A shebang filter on
that branch would drop them. It is also not needed there: 15 of 16 consumers scope that list with `**.sh`,
which no `.py` file can match. If a consumer ever needs to exclude something, the fix belongs in its glob,
not in this workflow silently ignoring what it was told to lint.

Both branches now share a single `shellcheck` invocation, and an empty list exits 0 with
`No shell scripts to lint.` instead of failing with a `shellcheck` usage error (exit 3) — `dependency-migrator`
is a live instance of that case, since its only executable file is the `.mjs` now filtered out.

### Shebang-less files

Excluded from the `ALL` sweep, deliberately. `shellcheck` cannot lint them anyway — with no shebang, no
`.sh`/`.bash` extension and no `shell=` directive it emits `SC2148` ("Tips depend on target shell and yours
is unknown") and fails. The `check-executables-have-shebangs` pre-commit hook is what keeps shebang-less
executables from being committed. There are **zero** such files across all 17 repos today. The `.sh`/`.bash`
extension clause is what preserves the loud `SC2148` signal for a future shebang-less `*.sh` file rather
than silently skipping it.

## Output: one invocation per file, with a verdict for each

The batched `-exec shellcheck {} +` printed only *problems*. Silence meant "passed" — and was
indistinguishable from a selector bug that quietly linted nothing, which is exactly the failure mode this
PR fixes. Both branches now share one loop that runs `shellcheck` once per file and prints a single status
line per file, then a summary.

A clean run now states what it checked:

```
PASS  ./test/shellcheck/test.sh
PASS  ./test/shellcheck/extensionless-script

shellcheck: 2 file(s) checked, 0 failed
```

A failing run puts the findings under the `FAIL` line of the file they belong to, keeps going, and
reports the total. Verbatim from a real CI run of the dogfood job with a deliberately-broken fixture
temporarily added to the branch ([run 32299539177](https://github.com/ppat/github-workflows/actions/runs/32299539177)):

```
FAIL  ./test/shellcheck/TEMP-deliberately-broken.sh

In ./test/shellcheck/TEMP-deliberately-broken.sh line 3:
if [ "${x}" = 1 ]; then
^-- SC1046 (error): Couldn't find 'fi' for this 'if'.
^-- SC1073 (error): Couldn't parse this if expression. Fix to allow more checks.


In ./test/shellcheck/TEMP-deliberately-broken.sh line 5:

^-- SC1047 (error): Expected 'fi' matching previously mentioned 'if'.
^-- SC1072 (error): Expected 'fi'. Fix any mentioned problems and try again.

For more information:
  https://www.shellcheck.net/wiki/SC1046 -- Couldn't find 'fi' for this 'if'.
  https://www.shellcheck.net/wiki/SC1047 -- Expected 'fi' matching previously...
  https://www.shellcheck.net/wiki/SC1072 -- Expected 'fi'. Fix any mentioned ...
PASS  ./test/shellcheck/test.sh
PASS  ./test/shellcheck/extensionless-script

shellcheck: 3 file(s) checked, 1 failed
##[error]Process completed with exit code 1.
```

Note the two `PASS` lines *after* the failure: every file is checked before the job gives up, so one bad
script no longer hides the state of the rest. That fixture was pushed only to produce this evidence and
has been removed from the branch.

An empty selection is now unmistakable, and distinct from "checked everything, all clean":

```
shellcheck: no shell scripts selected -- nothing was checked
```

This is a live case, not hypothetical — `dotfiles` selects zero files on the `ALL` branch (chezmoi conveys
the executable bit through `executable_` filename prefixes, so nothing in its source tree is executable).

Plain aligned status lines were chosen over `::group::` per file: at 28 files (the largest consumer)
collapsed groups would hide exactly the "what was checked" information this is meant to surface, and
would need expanding one by one to read.

### Exit-code aggregation

The easy thing to get wrong here is a loop that only reflects its last iteration. Proven by construction
against the extracted step run under GitHub Actions' own shell flags (`bash --noprofile --norc -eo pipefail`):

| Case | Result | Exit |
| --- | --- | --- |
| bad file in the **middle** | `4 file(s) checked, 1 failed` | 1 |
| bad file **first** | `3 file(s) checked, 1 failed` | 1 |
| bad file **last** | `3 file(s) checked, 1 failed` | 1 |
| **two** bad files | `4 file(s) checked, 2 failed` | 1 |
| all good | `3 file(s) checked, 0 failed` | **0** |
| empty selection (ALL branch) | `no shell scripts selected` | **0** |
| empty selection (caller list) | `no shell scripts selected` | **0** |

Non-zero if *any* file fails, zero only if all pass. `failed=$((failed + 1))` is used rather than
`((failed++))`, which would return 1 on the first increment and abort the step under `set -e`.

### Does per-file invocation change what shellcheck sees?

Checked rather than assumed, because it genuinely can. Batched invocation **does** cross-resolve `source`
between files given as input — `shellcheck main.sh lib.sh` follows `lib.sh`, while `shellcheck main.sh`
alone emits `SC1091: Not following: ./lib.sh was not specified as input`. So splitting the batch could in
principle introduce new SC1091 findings, and 6 of the 17 consumers do not disable SC1091.

In practice it changes nothing: **no selected file anywhere in the fleet statically sources another
selected file** (the only sources in selected files are dynamic, e.g. `source "${SCRIPT_DIR}/lib.sh"`,
which neither mode can resolve, and are already handled with inline `# shellcheck disable` directives).
Running batched vs. per-file over every consumer produced **byte-identical findings and exit codes in all
17 repos**, on both the `ALL` and the caller-supplied-list branches. `-x`/`--external-sources` is therefore
not needed, and was not added — it would have changed source resolution beyond what this PR is for.

Runtime on the largest consumer (`homelab-ops-kubernetes-apps`, 28 files): **1.4s**. Per-process overhead
is not a factor at these counts.

## Proof of no coverage loss

Captured against clean `origin/main` checkouts (`git archive`, so the executable bits are the real ones) of
**all 17 consuming repos**, comparing the exact file list fed to `shellcheck` before and after.

**13 of 17 repos: byte-identical file lists.**

```
coder                                    2 -> 2    IDENTICAL
dependency-migrator                      1 -> 0    DIFF (below)
dotfiles                                 0 -> 0    IDENTICAL
dotfiles-old                             0 -> 0    IDENTICAL
garage-falsification-harness            36 -> 24   DIFF (below)
github-workflows                         1 -> 1    IDENTICAL
homelab-ops-ansible                      6 -> 6    IDENTICAL
homelab-ops-kubernetes-apps             28 -> 28   IDENTICAL
homelab-ops-kubernetes-clusters         11 -> 7    DIFF (below)
homelab-ops-kubernetes-experiments       9 -> 9    IDENTICAL
homelab-ops-packer                       3 -> 3    IDENTICAL
homelab-ops-pi                           6 -> 6    IDENTICAL
homelab-ops-terraform                    0 -> 0    IDENTICAL
images                                   4 -> 3    DIFF (below)
obsidian-tools                           0 -> 0    IDENTICAL
test-kubernetes                          0 -> 0    IDENTICAL
validate-kubernetes-manifests            6 -> 6    IDENTICAL
```

The complete diff, verbatim. **Every removed line is a non-shell file; no shell script disappears anywhere:**

```diff
--- dependency-migrator
-./scripts/validate-mermaid.mjs

--- garage-falsification-harness
-./h1-rss-list/loader.py
-./h1-rss-list/measure_extra.py
-./h2-durability/cell_iteration.py
-./h2-durability/verify_cell.py
-./h3-listobjectsv2-barman/h3b_probe.py
-./h3-listobjectsv2-barman/repro.py
-./h4-lifecycle-expiration/h4b_retest.py
-./h4-lifecycle-expiration/h4d_inline_steady_state.py
-./h4-lifecycle-expiration/lifecycle_check.py
-./h5-longhorn-restore/checksum_verify.py
-./h5-longhorn-restore/garage-region-check.py
-./lib/keygen.py

--- homelab-ops-kubernetes-clusters
-./clusters/homelab/services/ci-diagnostics/scripts/ci-diagnostics.py
-./clusters/homelab/services/loki-query-correctness/loki-query-correctness.py
-./clusters/homelab/services/object-store-kpi-archive/object-store-kpi-archive.py
-./clusters/homelab/services/object-store-kpi-archive/tests/falsification-harness.py

--- images
-./obsidian/auto-trust.py
```

18 files removed, 18 non-shell. Nothing added, no shell script removed.

The per-file amendment changes *how* files are checked, not *which*: re-running the final step over all 17
repos and collecting the files named by its `PASS`/`FAIL` lines reproduces these exact lists, unchanged.

Supporting evidence:

- **Every distinct shebang** among all 113 currently-selected files across all 17 repos:
  `#!/usr/bin/env bash` (46), `#!/bin/bash` (38), `#!/usr/bin/env python3` (17), `#!/bin/sh` (11),
  `#!/usr/bin/env node` (1). The new predicate keeps exactly the first, second and fourth.
- **Running the new selector's output through real `shellcheck --rcfile .shellcheckrc` exits 0 in all 17 repos.**
  No genuine shell defects were unmasked by getting past the early SC1071 abort — `clusters` and
  `garage-falsification-harness` need no follow-up shell fixes.
- The step was extracted from this YAML and executed verbatim (not a transcription) to produce these results.
- 17 regex cases checked, including `#!/bin/bash -eu`, `#!/usr/bin/env -S bash -e`, CRLF line endings, and
  the near-misses `#!/bin/zsh` / `#!/usr/bin/env zsh` (correctly rejected — `zsh` is not a supported shell).
- Old-vs-new parity on the explicit-list branch: identical `shellcheck` invocation for `dotfiles`' 11-file
  list, and newline-separated lists still split correctly.

## Blast radius

16 consuming repos + this one. Verified by org-wide code search for `lint-shellcheck.yaml`, not assumed:

`coder`, `dependency-migrator`, `dotfiles`, `dotfiles-old`, `garage-falsification-harness`,
`homelab-ops-ansible`, `homelab-ops-kubernetes-apps`, `homelab-ops-kubernetes-clusters`,
`homelab-ops-kubernetes-experiments`, `homelab-ops-packer`, `homelab-ops-pi`, `homelab-ops-terraform`,
`images`, `obsidian-tools`, `test-kubernetes`, `validate-kubernetes-manifests`, and `github-workflows`
itself via `self-test-shellcheck.yaml`.

(`renovate-presets` and `homelab-ops-actions` do **not** consume this workflow.)

Consumers pin this workflow by tag/SHA, so nothing changes for them until they bump the pin.

## Tests

`test/shellcheck/` gains two fixtures, so `self-test-shellcheck.yaml` (which runs on this PR, since it
triggers on `lint-shellcheck.yaml` and `test/shellcheck/**`) actually falsifies the bug rather than just
passing:

- `not-a-shell-script.py` — executable, `#!/usr/bin/env python3`. **Confirmed to fail with SC1071 under
  the old selector** and to be skipped by the new one.
- `extensionless-script` — executable, `#!/usr/bin/env bash`, no extension. Guards the coverage-loss
  direction: scripts identified only by their shebang must still be linted.

A third, deliberately-broken fixture was pushed temporarily to prove the job actually goes red (it did — run
[32299539177](https://github.com/ppat/github-workflows/actions/runs/32299539177), `Process completed with exit code 1`)
and then removed, so the branch is clean.

`actionlint` (shellcheck-integrated), `yamllint --strict`, `markdownlint-cli2` and `pre-commit` all pass.

## Notes

- `homelab-ops-pi` has no `.shellcheckrc`, so `--rcfile .shellcheckrc` warns `unable to read --rcfile`
  and falls back to defaults. Pre-existing, non-fatal, out of scope here.
