### PR TITLE
chore(dev-tools): drop blanket shellcheck disables from .shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,31 +1,14 @@
-# SC1091: Can't follow non-constant source
-# https://github.com/koalaman/shellcheck/wiki/SC1090
-disable=SC1090
-
-# SC1091: Not following: (error message here)
-# https://github.com/koalaman/shellcheck/wiki/SC1091
-disable=SC1091
-
-# SC2046: Quote this to prevent word splitting.
-# https://github.com/koalaman/shellcheck/wiki/SC2046
-disable=SC2046
-
-# SC2059: Don't use variables in the printf format string.
-# https://github.com/koalaman/shellcheck/wiki/SC2059
-disable=SC2059
-
-# SC2068: Double quote array expansions to avoid re-splitting elements.
-# https://github.com/koalaman/shellcheck/wiki/SC2068
-disable=SC2068
-
-# SC2086: Double quote to prevent globbing and word splitting.
-# https://github.com/koalaman/shellcheck/wiki/SC2086
-disable=SC2086
-
-# SC2155: Declare and assign separately to avoid masking return values
-# https://github.com/koalaman/shellcheck/wiki/SC2155
-disable=SC2155
-
-# SC2236: Use -n instead of ! -z.
-# https://github.com/koalaman/shellcheck/wiki/SC2236
-disable=SC2236
+# ShellCheck configuration for this repository.
+#
+# Policy: no blanket `disable=` lines here. A repo-wide disable silences every
+# future occurrence of a rule, including ones nobody has looked at yet. Suppress
+# at the point of occurrence instead, with a comment saying why:
+#
+#   # shellcheck disable=SC2086  # intentional word splitting: $FILES is a path list
+#   shellcheck $FILES
+#
+# Scope: this file applies only to scripts linted via `shellcheck --rcfile
+# .shellcheckrc` (see lint-shellcheck.yaml). It does NOT apply to workflow `run:`
+# blocks checked by lint-github-actions.yaml -- actionlint always appends
+# `--norc` to the shellcheck command it invokes, so those require inline
+# `# shellcheck disable=` directives regardless of what is configured here.


### PR DESCRIPTION
## Summary

Removes the eight repo-wide `disable=` lines from `.shellcheckrc` and replaces them with a
comment recording the policy (suppress inline, at the point of occurrence, with a reason).

The investigation behind this turned up something worth more than the cleanup itself: **the
global disables were suppressing nothing that is actually linted in this repo**, and — separately
— **`lint-github-actions.yaml` has never actually run shellcheck at all**. Details below.

## Starting suppression inventory

`.shellcheckrc` (repo root) — the only suppression surface in the repo. No `--exclude`/`-e` flags
are passed to shellcheck anywhere in `.github/workflows/`, and there were zero pre-existing inline
`# shellcheck disable=` directives.

| Rule | Meaning | Scope |
|---|---|---|
| SC1090 | Can't follow non-constant source | repo-wide |
| SC1091 | Not following: (file) | repo-wide |
| SC2046 | Quote this to prevent word splitting | repo-wide |
| SC2059 | Don't use variables in the printf format string | repo-wide |
| SC2068 | Double quote array expansions | repo-wide |
| SC2086 | Double quote to prevent globbing and word splitting | repo-wide |
| SC2155 | Declare and assign separately | repo-wide |
| SC2236 | Use `-n` instead of `! -z` | repo-wide |

Two consumers reference it:

- `lint-shellcheck.yaml` → `shellcheck --rcfile .shellcheckrc <files>`
- `lint-github-actions.yaml` → `actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"`

Note the `.shellcheckrc` resolves against the *calling* repo's checkout (`working-directory: ./current`),
so this file governs **this repo only** — the other 11 consumer repos each carry their own copy.
Blast radius of this PR is therefore limited to `github-workflows`.

## Findings once the suppressions were lifted

### Path 1 — `lint-shellcheck.yaml` (rcfile is honoured here)

The file selector is `find . -type f -not -path './node_modules/*' -not -path './.git/*' -not -path ./bun.lock -executable`.
In a clean checkout that selects exactly one file, `test/shellcheck/test.sh` (`.terraform/` is gitignored):

```
$ find . -type f -not -path './node_modules/*' -not -path './.git/*' -not -path ./bun.lock -executable
./test/shellcheck/test.sh

$ shellcheck --norc test/shellcheck/test.sh ; echo $?
0
```

**Zero findings** with all suppressions removed. Every one of the eight global disables was dead on
this path.

### Path 2 — `lint-github-actions.yaml` (rcfile can never apply)

`actionlint` builds its own shellcheck argv and **always appends `--norc`**, which nullifies any
preceding `--rcfile`. Captured via a wrapper that logs its argv:

```
ARGV: --rcfile .shellcheckrc --norc -f json -x --shell bash -e SC1091,SC2194,SC2050,SC2154,SC2157,SC2043 -
```

So `.shellcheckrc` has never had any effect on workflow `run:` blocks, and never can. The only way
to suppress a rule there is an inline `# shellcheck disable=` directive inside the `run:` block.

**Further, at the actionlint version this repo pins (`v1.7.4`), shellcheck is not invoked at all.**
1.7.4 treats the entire `-shellcheck` string as an executable path, `LookPath` fails on
`"shellcheck --rcfile .shellcheckrc"`, and the rule is silently dropped — surfaced only under `-verbose`:

```
$ actionlint -verbose -shellcheck "shellcheck --rcfile .shellcheckrc" .github/workflows/lint-yaml.yaml
verbose: Rule "shellcheck" was disabled: exec: "shellcheck --rcfile .shellcheckrc": executable file not found in $PATH
```

Under a newer actionlint that does split arguments (v1.7.7), the same command reports **60 findings**
across 14 workflow files — mostly SC2086 on deliberately-unquoted `$FILES` variables, plus SC2129,
SC2076, SC2048, SC2034, SC2004. Those 60 are identical before and after this PR (see proof below),
because `--norc` dominates either way.

**I did not touch this.** Fixing the invocation would light up 60 findings in this repo and in all 11
consumer repos, immediately before a release, and the majority are exactly the word-splitting cases
where "fixing" the quoting changes what arguments a command receives at runtime. Flagged for a
separate, deliberate change — see "Runtime risk / left undone".

## Per-finding decisions

| Rule | Occurrences on a linted path | Decision | Rationale |
|---|---|---|---|
| SC1090 | 0 | Removed global | Nothing in this repo sources a file. Dead suppression. |
| SC1091 | 0 | Removed global | Same. (actionlint already excludes SC1091 itself via its own `-e` list.) |
| SC2046 | 0 | Removed global | No unquoted command substitutions on the linted path. |
| SC2059 | 0 | Removed global | No `printf` with a variable format string anywhere. |
| SC2068 | 0 | Removed global | No array expansions on the linted path. |
| SC2086 | 0 on the linted path (53 in `run:` blocks, unreachable by rcfile) | Removed global | The `run:`-block instances were never covered by this file. Removing it changes nothing; leaving it would keep implying coverage it does not provide. |
| SC2155 | 0 | Removed global | No `local`/`declare` + command substitution on the linted path. |
| SC2236 | 0 | Removed global | No `! -z` tests anywhere. |

No suppression was inlined, because there is no occurrence on a linted path to inline it at. No
suppression was left global.

## Behaviour-equivalence proof

No shell code was changed by this PR — the diff is one config file, comments only, and the eight
`disable=` lines. Argument construction is untouched everywhere. Verified anyway by running both
lint paths against the old and new rcfile at the versions CI pins (shellcheck `v0.11.0`,
actionlint `v1.7.4`):

```
=== shellcheck, CI's exact `files: ALL` command, over every executable file ===
old rcfile: exit=0
new rcfile: exit=0
diff old new -> IDENTICAL output

=== actionlint v1.7.4 (the version CI pins), CI's exact command ===
old rcfile: exit=0
new rcfile: exit=0
diff old new -> IDENTICAL output

=== actionlint v1.7.7 (newer; proves --norc dominance) ===
old rcfile: 60 findings
new rcfile: 60 findings
```

Also run clean: `yamllint --strict .`, `pre-commit run --all-files`.

## Commit type

`chore(dev-tools)` rather than `fix`. release-please derives the bump from the type, and this change
has provably zero runtime effect on any workflow — a `fix:` would force a patch bump for a no-op. If
you'd rather it appear in the changelog ahead of the release, say so and I'll retype it.

## Runtime risk / left undone

- **No runtime risk from this PR.** It changes only lint configuration that is demonstrably inert on
  every path CI exercises.
- **`lint-github-actions.yaml` is not actually shellchecking anything** (actionlint v1.7.4 argv bug,
  above). This affects this repo and all 11 consumers. Fixing it — either by splitting the flag the way
  newer actionlint expects, or by shipping a small wrapper script on PATH — is a real behavioural change
  that surfaces 60 findings, and belongs in its own PR after the release. Note that even then `--norc`
  means the fixes must be inline directives, not rcfile entries.
- The `run:`-block findings were deliberately **not** pre-emptively inlined. Adding ~60 speculative
  `# shellcheck disable=` comments for findings nobody currently sees, across 14 reusable workflows,
  right before a release, is churn without safety — and the correct disposition of each depends on
  whether the word-splitting there is intentional, which is a per-case judgement best made when the
  lint is actually running.
- Unrelated, noticed in passing, not changed: `CLAUDE.md` lists `pre-commit run shellcheck --all-files`
  under Commands, but `.pre-commit-config.yaml` has no shellcheck hook.
