### PR TITLE
fix(github-actions): scope github app tokens to the calling repo and least permissions

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,6 +36,10 @@ jobs:
         app-id: ${{ secrets.app_id }}
         private-key: ${{ secrets.app_private_key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.repository }}
+        permission-contents: write
+        permission-issues: write
+        permission-pull-requests: write
 
     - name: Setup repository and tools
       uses: ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -55,6 +55,10 @@ jobs:
         app-id: ${{ secrets.app_id }}
         private-key: ${{ secrets.app_private_key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.repository }}
+        permission-contents: write
+        permission-issues: write
+        permission-pull-requests: write
 
     - name: Setup repository and tools
       uses: ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -41,6 +41,7 @@ jobs:
         app-id: ${{ secrets.app_id }}
         private-key: ${{ secrets.app_private_key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.repository }}
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/update-aqua-checksums.yaml
+++ b/.github/workflows/update-aqua-checksums.yaml
@@ -52,6 +52,8 @@ jobs:
         app-id: ${{ secrets.app_id }}
         private-key: ${{ secrets.app_private_key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.repository }}
+        permission-contents: write
 
     - name: Setup repository and tools
       uses: ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0

--- a/README.md
+++ b/README.md
@@ -58,5 +58,17 @@ jobs:
       app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}
 ```
 
+Those tokens are minted scoped to the calling repository only, with an explicit permission set per
+workflow. The App installation behind `app_id`/`app_private_key` must already carry at least these
+permissions — `actions/create-github-app-token` fails outright when asked for one the installation
+does not have:
+
+| Workflow | Installation permissions requested |
+| --- | --- |
+| [`release-please.yaml`](.github/workflows/release-please.yaml) | `contents: write` (tags + releases), `pull-requests: write` (release PR), `issues: write` (`autorelease:*` labels) |
+| [`release-semantic.yaml`](.github/workflows/release-semantic.yaml) | `contents: write` (tags, releases, `@semantic-release/git` pushes), `pull-requests: write`, `issues: write` (release comments/labels) |
+| [`update-aqua-checksums.yaml`](.github/workflows/update-aqua-checksums.yaml) | `contents: write` (signed commit of the updated checksums) |
+| [`renovate.yaml`](.github/workflows/renovate.yaml) | whatever the installation grants — Renovate's needs are broad and config-dependent (contents, pull-requests, issues, workflows, packages, checks, statuses, members, vulnerability alerts) |
+
 See `.github/workflows/self-*.yaml` in this repo for complete, working call sites of every workflow
 above.

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,19 +1,18 @@
 ---
-# Pre-existing findings in already-merged workflows, accepted as known/tracked
-# risk rather than fixed here, to keep the zizmor gate's introduction scoped to
-# "add the gate" (see lint-zizmor.yaml). Revisit independently.
+# Accepted-risk finding for the zizmor gate (see lint-zizmor.yaml). Every other
+# `create-github-app-token` call site now scopes its token explicitly, via
+# `repositories:` plus a `permission-*` set derived from what the workflow
+# actually does.
 rules:
   github-app:
     ignore:
-    # All four call sites already scope RENOVATE_REPOSITORIES/operate on only
-    # `github.repository`, but omit explicit `repositories:`/`permission-*`
-    # inputs on `create-github-app-token`, so the token is broader than used.
-    # Narrowing these is a follow-up, not required for the zizmor gate itself.
-    - release-please.yaml:33
-    - release-please.yaml:38
-    - release-semantic.yaml:52
-    - release-semantic.yaml:57
+    # renovate.yaml is scoped to `repositories: github.repository`, but keeps
+    # blanket installation permissions: Renovate needs a broad, version- and
+    # config-dependent set (contents/pull-requests/issues/workflows/packages/
+    # checks/statuses/members/vulnerability-alerts), and the app installation
+    # backing it is already provisioned with exactly that set. Pinning
+    # `permission-*` here would restate it without narrowing anything, while
+    # hard-failing token minting for any consumer whose Renovate app carries a
+    # different set (create-github-app-token errors when asked for a permission
+    # the installation lacks).
     - renovate.yaml:38
-    - renovate.yaml:43
-    - update-aqua-checksums.yaml:49
-    - update-aqua-checksums.yaml:54


### PR DESCRIPTION
## What

Narrows the GitHub App tokens minted by the four workflows that use
`actions/create-github-app-token`, and drops 7 of the 8 `github-app` suppressions in `zizmor.yaml`.

Before, every call site passed only `owner: ${{ github.repository_owner }}` — so the minted token was
scoped to **every repository in the owner's app installation**, with **every permission that installation
holds**. Now each token is scoped to the calling repository, and three of the four request an explicit
permission set.

## ⚠️ Runtime risk — CI cannot prove this is correct

**This change cannot be fully verified by CI.** zizmor going green says nothing about whether
`release-please` can still push a tag, or whether Renovate can still open a PR. The write paths only run
during a real release / a real Renovate run.

What CI *does* prove (the PR touches all four workflow files, so `self-test-release-please`,
`self-test-semantic-release`, `self-test-aqua` and `self-renovate` all fire): **token minting succeeds
with the requested permissions.** That is the single biggest failure mode — `create-github-app-token`
[errors outright](https://github.com/actions/create-github-app-token/blob/bcd2ba49218906704ab6c1aa796996da409d3eb1/README.md)
if asked for a permission the installation lacks — and it is covered. `self-test-aqua` additionally
exercises the real write path (signed commit) if the checksums change.

What remains unproven, and what would break if a permission is wrong:

| If wrong | What breaks | When you'd find out |
| --- | --- | --- |
| `release-please.yaml` permissions | the release PR isn't created/updated, the tag+GitHub release isn't cut, or `autorelease:*` labels fail to apply | next push to `main` — i.e. **the release you are about to cut** |
| `release-semantic.yaml` permissions | `bunx semantic-release` fails to push the CHANGELOG commit, tag, or GitHub release in `ppat/coder`, `ppat/homelab-ops-ansible` | next `workflow_dispatch` release in those repos |
| `update-aqua-checksums.yaml` permissions | the signed commit (`createCommitOnBranch`) is rejected | next aqua checksum PR |
| `repositories:` scoping (all four) | any operation against a repo other than the calling one 403/404s | first run after adoption |

Mitigation if something does break: the change is one commit and consumers pin SHAs, so reverting is a
tag-pin rollback.

## Per-call-site permissions and the evidence for each

| Call site | Requested | Evidence from the workflow |
| --- | --- | --- |
| `release-please.yaml` | `repositories: github.repository`, `contents: write`, `pull-requests: write`, `issues: write` | Token goes to `setup-repository-tools` (checkout of `github.repository`, and `MISE_GITHUB_TOKEN`) and to `release-please github-release` + `release-please release-pr` via `--token`, both with `--repo-url=${{ github.repository }}` — no other repo is ever named. `github-release` creates the tag + GitHub release (`contents: write`); `release-pr` opens/updates the release PR (`pull-requests: write`); both manage labels — [PR #593](https://github.com/ppat/github-workflows/pull/593) carries `autorelease: tagged` and the `extra-label: pr-type:release` from `release-please-config.json`, and label create/apply goes through the issues API (`issues: write`). PR #593 touched only `CHANGELOG.md` + `.release-please-manifest.json`, never `.github/workflows/**`, so no `workflows: write` is needed (the backing App does not have it anyway). |
| `release-semantic.yaml` | `repositories: github.repository`, `contents: write`, `pull-requests: write`, `issues: write` | Token goes to `setup-repository-tools` with `current_repository: github.repository` and `current_persist_credentials: true` — so `@semantic-release/git` pushes the `CHANGELOG.md` commit over it (`contents: write`) — and to `bunx semantic-release` as `GITHUB_TOKEN`. `.releaserc.js` runs `@semantic-release/changelog`, `@semantic-release/exec`, `@semantic-release/git`, `@semantic-release/github`: tags + releases (`contents: write`), release comments/labels on the PRs and issues in the release (`issues: write`, `pull-requests: write`). The second checkout (`ppat/github-workflows`) deliberately uses the default `GITHUB_TOKEN`, not this token, so cross-repo scope isn't needed. |
| `update-aqua-checksums.yaml` | `repositories: github.repository`, `contents: write` | The token is used in exactly three places: the checkout of `github.repository`, `AQUA_GITHUB_TOKEN` for `aqua update-checksum` (reads *public* upstream releases — see note below), and `create-signed-commit`, whose only API calls are a `repository(...) { ref { target { oid } } }` query and the `createCommitOnBranch` mutation against `${{ github.repository }}`. Nothing opens a PR, comments, or labels — hence no `issues`/`pull-requests`. |
| `renovate.yaml` | `repositories: github.repository` **only** — permission suppression kept | `RENOVATE_REPOSITORIES` is hard-coded to `${{ github.repository }}` and is not overridable by callers (the workflow exposes no input for it), so repo scoping matches what Renovate is already told to operate on. Permissions are deliberately left blanket: Renovate's required set is broad and config-dependent (contents, pull-requests, issues, **workflows** for action-pin bumps, packages for the ghcr `hostRules` entry, checks/statuses for automerge, `vulnerability_alerts` for `osvVulnerabilityAlerts`), and the App installation behind it is already provisioned with exactly that set — so pinning `permission-*` would restate it without narrowing anything, while hard-failing token minting for any consumer whose Renovate app carries a different set. See the comment left in `zizmor.yaml`. |

### Why repo scoping is safe here

- All four workflows name only `${{ github.repository }}` (checkout, `--repo-url`, `RENOVATE_REPOSITORIES`,
  `create-signed-commit`'s `repository:`). No call site reaches another repo.
- Cross-repo *reads of public repos* are unaffected: the same token is already used today as
  `MISE_GITHUB_TOKEN` and `AQUA_GITHUB_TOKEN` to fetch releases from `jdx/mise`, `aquaproj/*`, etc., which
  are **outside** the installation — so installation scope was never what made those work.
- Renovate's preset sources were checked across every consumer: they resolve to `ppat/renovate-presets`,
  `ppat/github-workflows` (both public) or to `github>ppat/<self>//...` in the same repo. No consumer
  extends a preset from a *different private* repo.
- The ghcr `hostRules` entry is for public images; no `ghcr.io/ppat/*` image is referenced anywhere in the
  fleet (`ppat/images` publishes to Docker Hub + a private registry).

## zizmor: before → after

Command (as CI runs it, from repo root):
`zizmor --format=plain --min-severity=medium --min-confidence=high --persona=regular .` (v1.29.0, the
version pinned in `lint-zizmor.yaml`).

**Before** — with `zizmor.yaml` removed, i.e. the live finding set: **8 findings, all `github-app`, high
severity / high confidence** — two per call site:

```
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/release-please.yaml:38:9
        owner: ${{ github.repository_owner }}
        ^ token granted access to all repositories for this owner's app installation
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/release-please.yaml:33:13
      uses: actions/create-github-app-token@... ^ app token inherits blanket installation permissions
... same pair for release-semantic.yaml:57/52, renovate.yaml:43/38, update-aqua-checksums.yaml:54/49

71 findings (4 ignored, 59 suppressed): 0 informational, 0 low, 0 medium, 8 high
```

(With the old `zizmor.yaml` in place this already reported `No findings to report`, since all 8 were
suppressed.)

**After** — with `zizmor.yaml` removed, only one live finding is left:

```
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/renovate.yaml:38:13
      uses: actions/create-github-app-token@... ^ app token inherits blanket installation permissions

64 findings (4 ignored, 59 suppressed): 0 informational, 0 low, 0 medium, 1 high
```

**After, with the trimmed `zizmor.yaml`** (what CI sees): `No findings to report. Good job!`

### Suppressions dropped vs. retained

| Suppression | Status |
| --- | --- |
| `release-please.yaml:33` / `:38` | **dropped** — both findings fixed |
| `release-semantic.yaml:52` / `:57` | **dropped** — both findings fixed |
| `update-aqua-checksums.yaml:49` / `:54` | **dropped** — both findings fixed |
| `renovate.yaml:43` (repo scope) | **dropped** — fixed |
| `renovate.yaml:38` (blanket permissions) | **retained**, with an updated comment explaining exactly why |

## Also

- `README.md` gains a short table of the permissions each workflow now requests, since that is now a hard
  requirement on the consumer's App installation rather than an implicit one.
- No inputs, outputs or secrets changed; no behavior changed beyond token scope.

## Commit type

`fix(github-actions):` → **patch** bump. It's a security hardening of existing behavior, matching how
prior behavior-changing workflow fixes were typed here (e.g. #601). It is deliberately not `feat` (no new
capability) and not `chore` (it changes what the published workflows do at runtime). Say the word if you'd
rather this land as a minor to make it louder in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
