### PR TITLE
feat(github-actions)!: update actionlint to v1.7.12 and make its shellcheck rule actually run

### DIFF
--- a/.github/renovate/exceptions.json
+++ b/.github/renovate/exceptions.json
@@ -2,14 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "allowedVersions": "<=1.7.4",
-      "description": "actionlint > 1.7.4 cannot provide shellcheck arguments",
-      "matchPackageNames": [
-        "actionlint",
-        "rhysd/actionlint"
-      ]
-    },
-    {
       "allowedVersions": "<=1.6.6",
       "description": "retain compatibility with opentofu and group terraform upgrades together",
       "matchPackageNames": [

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -97,14 +97,16 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         # use the git ref segment after the final slash (as tag can contain a slash)
-        VERSION_RAW="$(echo $SOURCE_GIT_REF | grep -oE '[^/]+$')"
-        VERSION_SEMVER="$(echo $VERSION_RAW | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        VERSION_RAW="$(echo "$SOURCE_GIT_REF" | grep -oE '[^/]+$')"
+        VERSION_SEMVER="$(echo "$VERSION_RAW" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
         VERSION_SHA="$(git rev-parse --short HEAD)"
 
         set -x
-        echo "VERSION_SEMVER=$VERSION_SEMVER" >> $GITHUB_ENV
-        echo "VERSION_RAW=$VERSION_RAW" >> $GITHUB_ENV
-        echo "VERSION_SHA=$VERSION_SHA" >> $GITHUB_ENV
+        {
+          echo "VERSION_SEMVER=$VERSION_SEMVER"
+          echo "VERSION_RAW=$VERSION_RAW"
+          echo "VERSION_SHA=$VERSION_SHA"
+        } >> "$GITHUB_ENV"
 
     - name: Automatically set image tag from branch
       if: ${{ startsWith(env.SOURCE_GIT_REF_NORMALIZED, 'refs/heads/') }}
@@ -114,12 +116,12 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         # use the git ref segment after the final slash (as branch can contain a slash)
-        VERSION_RAW="$(echo $SOURCE_GIT_REF | grep -oE '[^/]+$' | sed -E 's/[^a-zA-Z0-9]+/-/g; s/(^-+)|(-+$)//g')"
+        VERSION_RAW="$(echo "$SOURCE_GIT_REF" | grep -oE '[^/]+$' | sed -E 's/[^a-zA-Z0-9]+/-/g; s/(^-+)|(-+$)//g')"
         VERSION_SHA="$(git rev-parse --short HEAD)"
 
         set -x
-        echo "VERSION_RAW=$VERSION_RAW" >> $GITHUB_ENV
-        echo "VERSION_SHA=$VERSION_SHA" >> $GITHUB_ENV
+        echo "VERSION_RAW=$VERSION_RAW" >> "$GITHUB_ENV"
+        echo "VERSION_SHA=$VERSION_SHA" >> "$GITHUB_ENV"
 
     - name: Automatically set image build cache parameters
       shell: bash
@@ -136,6 +138,7 @@ jobs:
           CACHE_LATEST=""
         else
           LAST_COMMIT_MSG=$(git log --oneline --no-merges -1)
+          # shellcheck disable=SC2076  # literal substring match is intended; unquoting would make [ci: bust-cache] a regex character class
           if [[ "$LAST_COMMIT_MSG" =~ "[ci: bust-cache]" ]]; then
             echo "Instruction to bust cache detected in commit message."
             echo "Disabling use of cache for the build. This build itself will still be cached."
@@ -161,9 +164,11 @@ jobs:
         fi
 
         set -x
-        echo "CACHE_FROM=\"$CACHE_FROM\"" >> $GITHUB_ENV
-        echo "CACHE_TO=\"$CACHE_TO\"" >> $GITHUB_ENV
-        echo "CACHE_LATEST=\"$CACHE_LATEST\"" >> $GITHUB_ENV
+        {
+          echo "CACHE_FROM=\"$CACHE_FROM\""
+          echo "CACHE_TO=\"$CACHE_TO\""
+          echo "CACHE_LATEST=\"$CACHE_LATEST\""
+        } >> "$GITHUB_ENV"
 
     - name: Show build parameters
       shell: bash
@@ -282,10 +287,13 @@ jobs:
         IMAGE_ID: ${{ steps.build-image.outputs.imageid }}
         IMAGE_TAG: ${{ steps.meta.outputs.version }}
         IMAGE_DIGEST: ${{ steps.build-image.outputs.digest }}
+      # yamllint disable-line rule:indentation
       run: |
-        echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
-        echo "image_id=${IMAGE_ID}" >> $GITHUB_OUTPUT
-        echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+        {
+          echo "digest=${IMAGE_DIGEST}"
+          echo "image_id=${IMAGE_ID}"
+          echo "image_tag=${IMAGE_TAG}"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Docker Hub Description
       if: ${{ env.PUBLISH_DOCKERHUB == 'true' }}

--- a/.github/workflows/chainsaw-test.yaml
+++ b/.github/workflows/chainsaw-test.yaml
@@ -73,16 +73,16 @@ jobs:
       run: |
         echo 'Creating kind cluster...'
         kind create cluster \
-          --name=${CLUSTER_NAME} \
-          --wait=${WAIT} \
-          --image=${CLUSTER_NODE_IMAGE} \
-          --config=${CONFIG}
+          --name="${CLUSTER_NAME}" \
+          --wait="${WAIT}" \
+          --image="${CLUSTER_NODE_IMAGE}" \
+          --config="${CONFIG}"
         kubectl version
 
     - name: Install flux in kind cluster
       shell: bash
       run: |
-        flux install --version ${FLUX_VERSION} --log-level debug
+        flux install --version "${FLUX_VERSION}" --log-level debug
         flux version
 
     - name: Run Chainsaw Tests
@@ -111,7 +111,7 @@ jobs:
 
         # Run tests with combined values
         set -x
-        chainsaw test ${TEST_PATH} \
-          --config ${CHAINSAW_CONFIG} \
+        chainsaw test "${TEST_PATH}" \
+          --config "${CHAINSAW_CONFIG}" \
           --values /tmp/values-ci.yaml \
           --fail-fast

--- a/.github/workflows/lint-commit-messages.yaml
+++ b/.github/workflows/lint-commit-messages.yaml
@@ -43,7 +43,7 @@ jobs:
       shell: bash
       # yamllint disable-line rule:indentation
       run: |
-        echo "FETCH_DEPTH=$((DEPTH + 1))" >> $GITHUB_ENV
+        echo "FETCH_DEPTH=$((DEPTH + 1))" >> "$GITHUB_ENV"
 
     - name: Setup repository and tools
       uses: ppat/homelab-ops-actions/actions/setup-repository-tools@9c16506c3c527478b6314c86ca961c0011d9f94a # v2.2.0
@@ -76,8 +76,8 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         if [[ ! -e bun.lock ]]; then
-          cp $GITHUB_WORKSPACE/tools/package.json .
-          cp $GITHUB_WORKSPACE/tools/bun.lock .
+          cp "$GITHUB_WORKSPACE/tools/package.json" .
+          cp "$GITHUB_WORKSPACE/tools/bun.lock" .
         fi
         bun install --frozen-lockfile
 
@@ -87,7 +87,7 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         set -x
-        bunx commitlint --color --from ${INPUTS_FROM} --to ${INPUTS_TO} --verbose
+        bunx commitlint --color --from "${INPUTS_FROM}" --to "${INPUTS_TO}" --verbose
       env:
         INPUTS_FROM: ${{ inputs.from }}
         INPUTS_TO: ${{ inputs.to }}

--- a/.github/workflows/lint-github-actions.yaml
+++ b/.github/workflows/lint-github-actions.yaml
@@ -23,7 +23,11 @@ on:
 
 env:
   # renovate: datasource=github-releases depName=rhysd/actionlint
-  ACTIONLINT_VERSION: "v1.7.4"
+  ACTIONLINT_VERSION: "v1.7.12"
+  # actionlint shells out to this binary for the `shellcheck` rule; pin it so the
+  # findings do not drift with whatever the runner image happens to ship.
+  # renovate: datasource=github-releases depName=koalaman/shellcheck
+  SHELLCHECK_VERSION: "v0.11.0"
 
 jobs:
   github-actions:
@@ -41,6 +45,7 @@ jobs:
         mise_toml: |
           [tools]
           actionlint = "${{ env.ACTIONLINT_VERSION }}"
+          shellcheck = "${{ env.SHELLCHECK_VERSION }}"
 
     - name: Lint github actions
       env:
@@ -49,12 +54,16 @@ jobs:
       working-directory: ./current
       # yamllint disable-line rule:indentation
       run: |
+        # actionlint always appends `--norc` to the shellcheck command it runs, so
+        # `--rcfile .shellcheckrc` never took effect. Findings in `run:` blocks must
+        # be handled inline with `# shellcheck disable=` directives instead.
         if [[ "${ACTIONS_FILES}" == "ALL" ]]; then
           set -x
-          actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"
+          actionlint -shellcheck shellcheck
           set +x
         else
           set -x
-          actionlint -shellcheck "shellcheck --rcfile .shellcheckrc" $ACTIONS_FILES
+          # shellcheck disable=SC2086  # intentional word splitting: $ACTIONS_FILES is a space-separated file list
+          actionlint -shellcheck shellcheck $ACTIONS_FILES
           set +x
         fi

--- a/.github/workflows/lint-hadolint.yaml
+++ b/.github/workflows/lint-hadolint.yaml
@@ -66,14 +66,16 @@ jobs:
         HADOLINT_ARGS=( "${CONFIG}" "${FAILURE_THRESHOLD}" "${VERBOSITY}" )
         FILE_LIST=$(mktemp)
         if [[ "${DOCKER_FILES}" == "ALL" ]]; then
-          find . -type f -name Dockerfile > ${FILE_LIST}
+          find . -type f -name Dockerfile > "${FILE_LIST}"
         else
-          echo ${DOCKER_FILES} | tr ' ' '\n' > ${FILE_LIST}
+          # shellcheck disable=SC2086  # intentional word splitting: $DOCKER_FILES is a space-separated file list
+          echo ${DOCKER_FILES} | tr ' ' '\n' > "${FILE_LIST}"
         fi
 
         lint_dockerfile() {
           local file="$1"
-          if hadolint ${HADOLINT_ARGS[*]} ${file}; then
+          # shellcheck disable=SC2048,SC2086  # intentional: each HADOLINT_ARGS element is a flag string that must word-split, and empty ones must vanish
+          if hadolint ${HADOLINT_ARGS[*]} "${file}"; then
             return 0
           else
             return 1
@@ -82,15 +84,15 @@ jobs:
 
         error_count=0
         while IFS= read -r file; do
-          if lint_dockerfile ${file}; then
+          if lint_dockerfile "${file}"; then
             echo "✅ ${file}"
           else
             echo "❌ ${file}"
             error_count=$((error_count + 1))
           fi
           echo
-        done < ${FILE_LIST}
+        done < "${FILE_LIST}"
 
-        if (( ${error_count} > 0 )); then
+        if (( error_count > 0 )); then
           exit 1
         fi

--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -64,6 +64,7 @@ jobs:
           CONFIG_PARAM="--config ./.markdownlint.yaml"
         fi
         if [[ "${MARKDOWN_FILES}" == "ALL" ]]; then
+          # shellcheck disable=SC2086  # intentional word splitting: $CONFIG_PARAM is either empty or a two-token "--config <path>" pair
           markdownlint-cli2 "**/*.md" $CONFIG_PARAM
         else
           FILTERED=""
@@ -78,6 +79,7 @@ jobs:
             exit 0
           fi
           set -x
+          # shellcheck disable=SC2086  # intentional word splitting: $FILTERED is a space-separated file list and $CONFIG_PARAM a "--config <path>" pair
           markdownlint-cli2 ${FILTERED} $CONFIG_PARAM
           set +x
         fi

--- a/.github/workflows/lint-renovate-config-check.yaml
+++ b/.github/workflows/lint-renovate-config-check.yaml
@@ -64,12 +64,12 @@ jobs:
           echo "Validating all 'extends' configuration files..."
           for rc in $(find .github/renovate -type f -name '*.json' | sort); do
             echo "${rc}:"
-            renovate-config-validator ${rc} | pr -t -o 4
+            renovate-config-validator "${rc}" | pr -t -o 4
           done
         else
           echo "Validating changed configuration files..."
           for rc in ${RENOVATE_CONFIG_FILES}; do
             echo "${rc}:"
-            renovate-config-validator ${rc} | pr -t -o 4
+            renovate-config-validator "${rc}" | pr -t -o 4
           done
         fi

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -57,5 +57,6 @@ jobs:
         if [[ "${YAML_FILES}" == "ALL" ]]; then
           yamllint -c .yamllint --list-files --strict --format github .
         else
+          # shellcheck disable=SC2086  # intentional word splitting: $YAML_FILES is a space-separated file list
           yamllint -c .yamllint --list-files --strict --format github $YAML_FILES
         fi

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -65,12 +65,14 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         set -x
+        # shellcheck disable=SC2086  # intentional: both vars are flag strings that must vanish entirely when empty
         release-please github-release \
           --repo-url="${RELEASE_PLEASE_REPO_URL}" \
           --token="${RELEASE_PLEASE_TOKEN}" \
           --config-file="release-please-config.json" \
           --manifest-file=".release-please-manifest.json" \
           ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}
+        # shellcheck disable=SC2086  # intentional: both vars are flag strings that must vanish entirely when empty
         release-please release-pr \
           --repo-url="${RELEASE_PLEASE_REPO_URL}" \
           --token="${RELEASE_PLEASE_TOKEN}" \

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -88,8 +88,8 @@ jobs:
       # yamllint disable-line rule:indentation
       run: |
         if [[ ! -e bun.lock ]]; then
-          cp $GITHUB_WORKSPACE/tools/package.json .
-          cp $GITHUB_WORKSPACE/tools/bun.lock .
+          cp "$GITHUB_WORKSPACE/tools/package.json" .
+          cp "$GITHUB_WORKSPACE/tools/bun.lock" .
         fi
         bun install --frozen-lockfile
 
@@ -102,9 +102,10 @@ jobs:
       working-directory: ./current
       run: |
         echo
+        # shellcheck disable=SC2034  # not unused: GITHUB_REF is already exported by the runner, so this overrides what semantic-release reads from the environment
         GITHUB_REF=$CURRENT_BRANCH
         set -x
-        bunx semantic-release --dry-run --no-ci --branches $CURRENT_BRANCH
+        bunx semantic-release --dry-run --no-ci --branches "$CURRENT_BRANCH"
 
     - name: Release
       if: ${{ (github.event_name == 'workflow_dispatch') && (!inputs.dry_run) }}

--- a/.github/workflows/update-aqua-checksums.yaml
+++ b/.github/workflows/update-aqua-checksums.yaml
@@ -77,19 +77,21 @@ jobs:
       run: |
         DIR_LIST=$(mktemp)
         if [[ "${AQUA_DIRS}" == "ALL" ]]; then
-          find . -type f -name aqua.yaml -exec dirname {} \; | sort | uniq > ${DIR_LIST}
+          find . -type f -name aqua.yaml -exec dirname {} \; | sort | uniq > "${DIR_LIST}"
         else
-          echo ${AQUA_DIRS} | tr ' ' '\n' > ${DIR_LIST}
+          # shellcheck disable=SC2086  # intentional word splitting: $AQUA_DIRS is a space-separated directory list
+          echo ${AQUA_DIRS} | tr ' ' '\n' > "${DIR_LIST}"
         fi
 
         echo "Updating checksums..."
         while IFS= read -r dir; do
           echo "${dir}"
           pushd "${dir}" > /dev/null 2>&1
+          # shellcheck disable=SC2086  # intentional: $PRUNE is a flag string that must vanish entirely when empty
           aqua update-checksum ${PRUNE} 2>&1 | pr -t -o 4
           popd > /dev/null 2>&1
           echo
-        done < ${DIR_LIST} | pr -t -o 4
+        done < "${DIR_LIST}" | pr -t -o 4
 
         echo "Staging changes..."
         git add -A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,16 +26,28 @@ See [README.md](README.md) for what each workflow does and how to call one from 
 
 ## Commands
 
-No build step. `pre-commit` (yamllint, markdownlint-cli2, shellcheck, commitlint) is the primary local
-tooling:
+No build step. `pre-commit` (yamllint, markdownlint-cli2, commitlint) is the primary local tooling:
 
 ```bash
 pre-commit install
 pre-commit run --all-files
 pre-commit run yamllint --all-files
-pre-commit run shellcheck --all-files
 pre-commit run markdownlint-cli2 --all-files
 ```
+
+`shellcheck` is not a pre-commit hook; it runs only in CI, from two independent places:
+
+```bash
+# standalone scripts, as lint-shellcheck.yaml runs them (honours .shellcheckrc)
+shellcheck --rcfile .shellcheckrc <file>...
+
+# workflow `run:` blocks, as lint-github-actions.yaml runs them
+actionlint -shellcheck shellcheck
+```
+
+actionlint always appends `--norc` to the shellcheck command it invokes, so `.shellcheckrc` does
+**not** apply to `run:` blocks — suppress those findings with an inline `# shellcheck disable=SCxxxx`
+comment at the occurrence, never with a repo-wide disable.
 
 Lint a commit message locally:
 


### PR DESCRIPTION
## Summary

`lint-github-actions.yaml` invoked actionlint as:

```
actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"
```

At the pinned **v1.7.4** that entire string is treated as one executable path. `LookPath` fails and actionlint **silently disables the shellcheck rule** — non-fatal, and visible only under `-verbose`. shellcheck has therefore **never** run against workflow `run:` blocks in this repo or in any consuming repo, and README's "shellcheck-integrated" description was false.

This bumps actionlint **v1.7.4 → v1.7.12** (latest, 2026-03-30), fixes the invocation, resolves all 59 findings the working integration surfaces, and drops the Renovate hold-back.

## Proof the rule now runs

Before (v1.7.4, current invocation):

```
$ actionlint -verbose -shellcheck "shellcheck --rcfile .shellcheckrc"
verbose: Rule "shellcheck" was disabled: exec: "shellcheck --rcfile .shellcheckrc": executable file not found in $PATH
```

After (v1.7.12, new invocation) — the disable line is gone:

```
$ actionlint -verbose -shellcheck shellcheck 2>&1 | grep -c 'Rule "shellcheck" was disabled'
0
```

A clean run is not by itself proof the rule is on, so a canary confirms it is live rather than merely quiet — injecting `rm -rf $UNQUOTED_CANARY` into `lint-yaml.yaml`:

```
.github/workflows/lint-yaml.yaml:56:7: shellcheck reported issue in this script: SC2086:info:1:8: Double quote to prevent globbing and word splitting [shellcheck]
EXIT=1
```

Final state: `actionlint -shellcheck shellcheck` exits **0**; `yamllint --strict`, `pre-commit run --all-files` and repo-wide `shellcheck` are clean.

## What changed upstream between v1.7.4 and v1.7.12

The pin's stated reason — *"actionlint > 1.7.4 cannot provide shellcheck arguments"* — was fixed two releases later and the hold-back outlived it:

> **v1.7.5** — Allow passing command arguments to `-shellcheck` argument. (#483)

`findExe` now `LookPath`s the whole string first and falls back to shellwords-splitting it. Note the failure mode was **not** changed: a bad `-shellcheck` value is still silently non-fatal in v1.7.12, so this class of bug can recur.

Other notable upstream changes in the range (none of which fire on this repo, but they will reach consumers):

| Version | Change that can newly fail a previously-clean workflow |
| --- | --- |
| v1.7.5 | Strict `${{ }}` context-availability checking; `fromJSON()` string literals type-checked; `macos-12` removed |
| v1.7.8 | `ubuntu-20.04` / `windows-2019` labels removed; `ubuntu-latest` now resolves to `ubuntu-24.04`; YAML parser swapped to `yaml/go-yaml@v4` |
| v1.7.9 | Constant `if:` conditions (`if: true`) are errors; deprecated action inputs are errors; unexpected step keys detected more accurately |
| v1.7.10 | **YAML merge keys `<<` are errors**; unused/undefined YAML anchors are errors; `macos-13*` labels removed |
| v1.7.11 | Path filters starting with `./` are errors; `SC2153` added to actionlint's shellcheck exclusion list (strictly fewer findings) |
| v1.7.12 | `on.schedule[].timezone` validated against IANA names; webhook activity-type tables corrected |

**Nothing new fires here.** With the shellcheck rule off, v1.7.4 and v1.7.12 produce a byte-identical (empty) finding set on this repo, so every one of the 59 findings below is attributable to the shellcheck rule waking up, not to a new check.

## `--rcfile .shellcheckrc` was always a no-op

actionlint unconditionally appends `--norc`, still true at v1.7.12 (`rule_shellcheck.go`):

```go
args := []string{"--norc", "-f", "json", "-x", "--shell", sh, "-e", "SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043", "-"}
```

The observed argv, captured with a stub shellcheck:

```
--rcfile .shellcheckrc --norc -f json -x --shell bash -e SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043 -
```

`--norc` wins regardless of order (shellcheck short-circuits before config resolution), and the script arrives on stdin so directory discovery cannot apply either. Empirically: `.shellcheckrc` on `main` contains `disable=SC2086`, yet 53 SC2086 findings are still reported. Passing the flag was therefore dropped, and findings are handled with **inline directives at the occurrence** per the convention established in #604. This is unaffected by #604 removing the blanket disables, exactly as that PR's note predicted.

## Per-finding decisions — 59 total: 43 fixed, 16 inline-suppressed

Guiding rule: **if a change alters what arguments a command receives, it was not made.**

### Fixed (43)

| File | Construct | Rule | Decision |
| --- | --- | --- | --- |
| build-docker-image.yaml | `echo $SOURCE_GIT_REF` ×2, `echo $VERSION_RAW` | SC2086 | quoted — git refs cannot contain spaces |
| build-docker-image.yaml | `>> $GITHUB_ENV` ×7, `>> $GITHUB_OUTPUT` ×3 | SC2086 | quoted — runner-provided paths; matches existing `>> "$GITHUB_OUTPUT"` usage in this repo |
| build-docker-image.yaml | 3× repeated `>>` in three blocks | SC2129 | rewritten as `{ ...; } >> "$file"` |
| chainsaw-test.yaml | `--name= --wait= --image= --config=` | SC2086 | quoted — single-token inputs |
| chainsaw-test.yaml | `flux install --version`, `chainsaw test`, `--config` | SC2086 | quoted — single paths/versions |
| lint-commit-messages.yaml | `>> $GITHUB_ENV`, `cp $GITHUB_WORKSPACE/...` ×2, `--from`/`--to` | SC2086 | quoted — single tokens |
| lint-hadolint.yaml | `> ${FILE_LIST}` ×2, `done < ${FILE_LIST}` | SC2086 | quoted — `mktemp` path |
| lint-hadolint.yaml | `${file}` in `hadolint`/`lint_dockerfile` | SC2086 | quoted — argv-identical for all real paths; only differs for paths containing whitespace, where current behaviour is already broken |
| lint-hadolint.yaml | `(( ${error_count} > 0 ))` | SC2004 | `$` dropped — cosmetic |
| lint-renovate-config-check.yaml | `renovate-config-validator ${rc}` ×2 | SC2086 | quoted — one file per loop iteration |
| release-semantic.yaml | `cp $GITHUB_WORKSPACE/...` ×2, `--branches $CURRENT_BRANCH` | SC2086 | quoted — single tokens |
| update-aqua-checksums.yaml | `> ${DIR_LIST}` ×2, `done < ${DIR_LIST}` | SC2086 | quoted — `mktemp` path |

### Inline-suppressed (16) — quoting would change argv or break semantics

| File | Construct | Rule | Why suppressed |
| --- | --- | --- | --- |
| lint-github-actions.yaml | `$ACTIONS_FILES` | SC2086 | space-separated file list; quoting collapses N files into 1 argument |
| lint-yaml.yaml | `$YAML_FILES` | SC2086 | same |
| lint-markdown.yaml | `$CONFIG_PARAM` ×2, `${FILTERED}` | SC2086 | `$CONFIG_PARAM` is an empty-or-two-token `--config <path>` pair; `$FILTERED` is a file list |
| lint-hadolint.yaml | `${DOCKER_FILES}` | SC2086 | file list; quoting would also preserve runs of spaces and emit blank lines into the file list |
| lint-hadolint.yaml | `${HADOLINT_ARGS[*]}` | SC2048, SC2086 | elements are flag strings that must word-split, and empty ones must vanish; `"${HADOLINT_ARGS[@]}"` passes empty strings as real arguments |
| release-please.yaml | `${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}` ×2 lines | SC2086 | flag strings that must disappear entirely when empty |
| update-aqua-checksums.yaml | `${AQUA_DIRS}`, `${PRUNE}` | SC2086 | directory list; flag string that must vanish when empty |
| build-docker-image.yaml | `[[ "$MSG" =~ "[ci: bust-cache]" ]]` | SC2076 | see below |
| release-semantic.yaml | `GITHUB_REF=$CURRENT_BRANCH` | SC2034 | see below |

## argv-equivalence proofs

Every fix, run before/after against a stub that prints its argv, using the values consumers actually pass:

```
kind create cluster (4 flags)                  IDENTICAL argv
flux install --version                         IDENTICAL argv
chainsaw test (real consumer values)           IDENTICAL argv
cp $GITHUB_WORKSPACE/tools/package.json        IDENTICAL argv
bunx commitlint --from/--to                    IDENTICAL argv
semantic-release --branches                    IDENTICAL argv
renovate-config-validator ${rc}                IDENTICAL argv
hadolint ${file} -> "${file}" (normal path)    IDENTICAL argv
lint_dockerfile ${file} -> quoted              IDENTICAL argv
```

And each suppression, showing that the "fix" shellcheck suggests **does** change argv:

```
hadolint ${HADOLINT_ARGS[*]}  ->  "${HADOLINT_ARGS[@]}"
  unquoted (kept):   argc=3  [--failure-threshold] [warning] [f]
  quoted (rejected): argc=4  [] [--failure-threshold warning] [] [f]

release-please ${DRY_RUN} ${VERBOSE}   (both empty)
  unquoted (kept):   argc=2  [github-release] [--repo-url=x]
  quoted (rejected): argc=4  [github-release] [--repo-url=x] [] []

markdownlint-cli2 $CONFIG_PARAM
  unquoted (kept):   argc=3  [**/*.md] [--config] [./.markdownlint-cli2.yaml]
  quoted (rejected): argc=2  [**/*.md] [--config ./.markdownlint-cli2.yaml]

yamllint $YAML_FILES  /  actionlint $ACTIONS_FILES  /  markdownlint ${FILTERED}
  unquoted (kept):   one argument per file
  quoted (rejected): all files collapsed into a single argument

aqua update-checksum ${PRUNE}   (empty)
  unquoted (kept):   argc=1  [update-checksum]
  quoted (rejected): argc=2  [update-checksum] []
```

SC2129 rewrite — file content and exit status identical, append semantics preserved, and `{ }` is not a subshell so `set -e` behaviour is unchanged:

```
IDENTICAL file content + exit status:
VERSION_SEMVER=1.2.3
VERSION_RAW=main
VERSION_SHA=abc123
rc=0
```

### SC2076 — "fixing" it would silently disable the cache-bust escape hatch

Unquoting the right-hand side makes `[ci: bust-cache]` a bracket expression containing `t-c`, a **reverse range**, which is an invalid regex:

```
unquoted-regex form:  exit=2   (0=match, 1=no-match, 2=INVALID REGEX)
quoted-literal form:  exit=0   (matches)
[t-c] exit=2  (invalid range)     [a-z] exit=0  (valid, for contrast)
```

bash returns 2, `if` treats that as false, so `[ci: bust-cache]` would **never** be detected again. The quoted literal substring match is required. (`== *"[ci: bust-cache]"*` would be an equivalent directive-free alternative, but the current behaviour is not a bug, so it was left alone.)

### SC2034 — `GITHUB_REF` is not unused

`GITHUB_REF` is pre-exported by the runner, so assigning to it modifies the already-exported variable and it **does** reach the child process:

```
case 1  pre-exported, assignment present (real GHA):  child sees GITHUB_REF=<feat/x>
case 2  assignment deleted ("fixing" SC2034):         child sees GITHUB_REF=<refs/pull/42/merge>
case 3  not pre-exported:                             child sees GITHUB_REF=<unset>
```

Deleting it would silently change which branch `semantic-release` releases from — exactly the trap this rule sets.

## Also changed

- **shellcheck is now pinned.** `lint-github-actions.yaml` never installed shellcheck, so with the rule live it would have used whatever the runner image ships and the findings would drift with image updates. It is now pinned to `v0.11.0` and installed via mise with a `# renovate:` comment, matching `lint-shellcheck.yaml` exactly. This also means a missing shellcheck fails the setup step loudly instead of silently disabling the rule again.
- **CLAUDE.md** claimed `pre-commit run shellcheck --all-files` works and listed shellcheck as a pre-commit hook; `.pre-commit-config.yaml` has no such hook. Corrected, and the `--norc` consequence documented. README's "shellcheck-integrated" wording is left as-is because this change makes it **true** for the first time.
- Added a `# yamllint disable-line rule:indentation` to one `run:` block in `build-docker-image.yaml`, matching the three neighbouring blocks, since the `{ }` group indents its body.

## Renovate hold-back

It lived in **this repo**, at `.github/renovate/exceptions.json` — **not** in `ppat/renovate-presets`. I cloned and checked the presets repo: it contains no `actionlint` rule and no `allowedVersions` key at all, so **no second PR is needed**.

```diff
-    {
-      "allowedVersions": "<=1.7.4",
-      "description": "actionlint > 1.7.4 cannot provide shellcheck arguments",
-      "matchPackageNames": ["actionlint", "rhysd/actionlint"]
-    },
```

The unrelated `hashicorp/terraform` exception is untouched.

## Runtime risk statement

**CI cannot verify these decisions.** These are reusable workflows executed by consumer repos; a wrong quoting call breaks them at runtime, and the only workflow this repo dogfoods end-to-end is `chainsaw-test.yaml` (via `self-test-chainsaw.yaml`).

If a quoting decision is wrong, the failure lands here:

| Workflow | Failure mode if wrong | Covered by a self-test? |
| --- | --- | --- |
| `build-docker-image.yaml` | Highest consequence. `VERSION_*` and `CACHE_*` propagate via `$GITHUB_ENV`; a botched `{ }` group would mis-tag images or silently disable the build cache. The SC2076 suppression guards the `[ci: bust-cache]` escape hatch. | `self-test-docker.yaml` — exercises the build |
| `release-please.yaml` / `release-semantic.yaml` | Release-path. Wrongly quoting `${RELEASE_PLEASE_DRY_RUN}` would pass an empty argument to the CLI; wrongly deleting `GITHUB_REF` would change the released branch. **Both were suppressed, not fixed, for this reason.** | `self-test-semantic-release.yaml` (semantic only); release-please is not dry-run tested |
| `lint-hadolint.yaml` | `${HADOLINT_ARGS[*]}` splitting is load-bearing; quoting would pass empty args and a fused `--failure-threshold warning` token | no self-test |
| `chainsaw-test.yaml` | Quoted `--name=/--wait=/--image=/--config=` and `chainsaw test` args — verified against every `test_path`/`chainsaw_config`/`kind_config` value in use across consumers, all single paths | **yes**, `self-test-chainsaw.yaml` |
| `update-aqua-checksums.yaml` | `${PRUNE}` must vanish when empty — suppressed | `self-test-aqua.yaml` |

Mitigations actually applied: every fix is argv-proven against real consumer values (above); nothing whose argv would change was touched; suppression was preferred over fixing on all release-path and argument-building code.

**Consumer exposure:** most consumers pin this workflow by commit SHA and will only pick this up when Renovate bumps them. Three repos track `@main` and get it immediately — `dotfiles-old`, `self-hosted-renovate`, `test-kubernetes`. Their workflow `run:` blocks have never been shellcheck-linted, so they may go red on first run. That is the intended effect of turning the gate on, but it is worth expecting rather than being surprised by.

## Rebase onto #603 + #604 (2026-08-19)

Rebased onto current `main` after #603 (per-file shellcheck invocation) and #604 (blanket disables removed from `.shellcheckrc`) merged. One conflict, in `lint-shellcheck.yaml`.

**Resolution: this PR no longer touches `lint-shellcheck.yaml` at all.** The line my `SC2086` directive protected — `shellcheck --rcfile .shellcheckrc $SHELLSCRIPT_FILES` — no longer exists. #603 replaced it with a quoted per-file invocation (`shellcheck --rcfile .shellcheckrc "${file}"`) and moved the caller's list into an array with its own `# shellcheck disable=SC2206`. So the directive was obsolete, not merely relocated — verified rather than assumed:

```
$ actionlint -shellcheck shellcheck .github/workflows/lint-shellcheck.yaml
EXIT=0
```

The file is byte-identical to `origin/main`; #603's selection logic, `PASS`/`FAIL` output and `failed` exit-code aggregation are untouched, and none of this PR's directives live in that file.

**Finding-set delta: 60 → 59.** The single removed finding is exactly the `lint-shellcheck.yaml` SC2086 that #603 fixed. Nothing else moved:

```
old base (pre-#603/#604):  60 findings
new base (post-#603/#604): 59 findings
diff: -.github/workflows/lint-shellcheck.yaml:51:7: ... SC2086 ...   (that line only)
```

Triage is now **43 fixed / 16 inline-suppressed**; SC2086 goes 53 → 52 (39 fixed, 13 suppressed). Every other decision is unchanged.

**#604 provably does not reach this PR.** Rather than assume `--norc` makes the rcfile irrelevant, I swapped #604's `.shellcheckrc` for the old one containing all eight blanket disables and re-ran:

```
with #604 rcfile (no disables):              59 findings
with OLD rcfile (disable=SC2086 + 7 more):   59 findings
=> IDENTICAL
```

And re-passing the dropped flag changes nothing either, confirming its removal is a no-op:

```
actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"  =>  identical 59
```

**Re-verified post-rebase.** `-verbose` shows zero `Rule "shellcheck" was disabled` lines, and the canary still fires — a clean run alone cannot distinguish "live and passing" from "silently disabled", which is the failure mode that hid here for eight releases:

```
$ actionlint -shellcheck shellcheck                       # rebased branch
EXIT=0
$ actionlint -shellcheck shellcheck   # with rm -rf $UNQUOTED_CANARY injected
.github/workflows/lint-yaml.yaml:56:7: ... SC2086 ... [shellcheck]
EXIT=1   => rule is live
```

`yamllint --strict` and `pre-commit run --all-files` are clean on the rebased branch, and #603's selection logic run locally against #604's rcfile checks 2 files, 0 failed.

## Note on `main`'s post-merge state

`self-lint.yaml` has **no `push` trigger** (only `pull_request`, `schedule`, `workflow_dispatch`), so **no lint workflow ran on `main` when #603/#604 merged** — the only thing that ran was `self-release-please`. `main`'s lint status was therefore unverified rather than green. I dispatched `self-lint` and `self-test-shellcheck` on `main` to establish it; result reported on the PR.

## Commits and release type — intentionally MAJOR

Two commits, ordered so that **each is independently green**:

1. `fix(github-actions): quote shell expansions and annotate intentional word splitting in run blocks` — a no-op under the pinned v1.7.4 where the rule is off, verified to exit 0 against the old version *and* old invocation.
2. `feat(github-actions)!: update actionlint to v1.7.12 and make its shellcheck rule actually run` — the bump, invocation, shellcheck pin, Renovate hold-back and docs.

**This is deliberately a major bump, not a minor.** The `with:`/`secrets:` interface is unchanged, so it is not breaking by interface — but the workflow newly enforces a shellcheck gate that was silently dead for eight releases, so a consumer's first pin bump may turn its CI red. A major forces that to be a deliberate decision rather than a surprise, and it stops a red-making change from auto-landing unattended anywhere Renovate auto-merges minor bumps.

Carried **both** ways, because they are honoured at different points:

- `feat(github-actions)!:` — the bang, in both the commit subject and the **PR title**;
- a `BREAKING CHANGE:` footer in the commit body.

Verified rather than assumed. This repo's own history settles it: `bcdcaa7 refactor!: ...` carries a bang and **no** `BREAKING CHANGE:` footer, and produced **v3.0.0** under this exact `release-please-config.json` (`release-type: simple`), appearing under "⚠ BREAKING CHANGES". `changelog-sections` only controls section headings; it does not affect breaking-change detection.

**Why both forms matter here:** the repo is squash-merge-only (`allow_merge_commit=false`, `allow_rebase_merge=false`) with `squash_commit_title=COMMIT_OR_PR_TITLE`. With more than one commit in a PR, GitHub uses the **PR title** as the squash subject — so a bang living only in the commit subject would have been dropped on merge. The PR title now carries it, and `squash_commit_message=COMMIT_MESSAGES` means the `BREAKING CHANGE:` footer lands in the squash body as a second, independent trigger.

### release-please dry-run — computed version

Run against this branch (`release-pr --dry-run --target-branch=chore/modernize-actionlint`, release-please 17.11.1, the pinned version). `github-release` was deliberately **not** run, so nothing could be tagged:

```
chore(release): release v5.0.0
changelog compare link: compare/v4.4.0...v5.0.0
```

**v4.4.0 → v5.0.0.** The footer text is what renders in the changelog:

```
### ⚠ BREAKING CHANGES

* **github-actions:** lint-github-actions.yaml now enforces shellcheck against workflow
  `run:` blocks. That rule was silently disabled for eight releases, so the first bump to
  this version can surface pre-existing findings and turn a consumer's CI red. ...
```

The dry-run created nothing: no new PR, and the latest release is still `v4.4.0`. For corroboration, release-please's standing PR #599 against `main` currently computes **v4.5.0** — because `main` has no breaking commit yet. It will recompute to **v5.0.0** once this merges.

## ⚠️ The major tag does NOT protect everyone

Three repos reference these workflows at **`@main`**, not by tag or SHA:

- `dotfiles-old`
- `self-hosted-renovate`
- `test-kubernetes`

**They receive the newly-live shellcheck gate the moment this PR merges, independent of the version tag.** Their workflow `run:` blocks have never been shellcheck-linted, so they may go red immediately. The major signal only benefits consumers pinning by tag or SHA, whose adoption is a deliberate Renovate bump they can review. Anyone reviewing or merging this should expect those three to need triage at merge time.

## Deliberately not done

- **pyflakes is also silently disabled** (`Rule "pyflakes" was disabled: exec: "pyflakes": executable file not found in $PATH`) — the same failure class, pre-existing and out of scope here. Enabling it would surface an unreviewed finding set on Python `run:` blocks. Worth a follow-up.
- `lint-shellcheck.yaml` is **not touched by this PR** (see the rebase note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
