### PR TITLE
refactor(github-actions): split release-please into separate github-release and release-pr steps

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -56,7 +56,17 @@ jobs:
     # call order (`manifest.createReleases()` then
     # `manifest.createPullRequests()` in manifest mode, which this workflow
     # uses since no `release-type` is set).
-    - name: Release Please
+    #
+    # These are two steps, not one, so that a `github-release` failure stops
+    # the job before `release-pr` runs (default step semantics: no
+    # `if: always()`, no `continue-on-error`). The commands share state via
+    # the git tag `github-release` creates - `release-pr` computes "commits
+    # since last tag" to pick the next version. If `github-release` fails, no
+    # tag exists, so a `release-pr` that still ran would treat the
+    # just-merged release commit as unreleased and open a release PR with the
+    # wrong version and contents. Skipping it costs nothing: the next push or
+    # a re-run produces both correctly.
+    - name: Release Please - create GitHub release
       env:
         RELEASE_PLEASE_REPO_URL: ${{ github.repository }}
         RELEASE_PLEASE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -72,6 +82,16 @@ jobs:
           --config-file="release-please-config.json" \
           --manifest-file=".release-please-manifest.json" \
           ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}
+
+    - name: Release Please - create release PR
+      env:
+        RELEASE_PLEASE_REPO_URL: ${{ github.repository }}
+        RELEASE_PLEASE_TOKEN: ${{ steps.app-token.outputs.token }}
+        RELEASE_PLEASE_DRY_RUN: "${{ inputs.dry_run && '--dry-run' || '' }}"
+        RELEASE_PLEASE_VERBOSE: "${{ inputs.verbose && '--debug' || '' }}"
+      # yamllint disable-line rule:indentation
+      run: |
+        set -x
         # shellcheck disable=SC2086  # intentional: both vars are flag strings that must vanish entirely when empty
         release-please release-pr \
           --repo-url="${RELEASE_PLEASE_REPO_URL}" \


### PR DESCRIPTION
## Summary

Splits the single `Release Please` step in `release-please.yaml` (which ran
`release-please github-release` then `release-please release-pr` in one
`run:` block) into two steps, `Release Please - create GitHub release` and
`Release Please - create release PR`, in the same job. The command lines
themselves are byte-for-byte unchanged - same flags, same env var names and
values, same order. See the diff: everything outside the step boundary is
identical.

## Why split at all

`github-release` and `release-pr` share state through the git tag that
`github-release` creates: `release-pr` determines the next version from
"commits since the last tag". If `github-release` fails, no tag gets
created, so a `release-pr` that still ran would treat the just-merged
release commit as unreleased and open a release PR with the wrong version
and the wrong contents. Skipping `release-pr` when `github-release` fails
costs nothing - the next push or a manual re-run produces both correctly.

Splitting into two steps makes that ordering dependency visible in the job
graph (distinct names/timings in the Actions UI, a hook for future
per-step conditions or timeouts) without changing behavior.

**Deliberately not done:** no `if: always()`, no `continue-on-error` on
either step, and this stays two steps in one job rather than two jobs -
they're strictly sequential and separate jobs would mint the GitHub App
token twice for no benefit.

## What I found before changing anything

I checked whether the existing single step already failed fast, since a
`run:` block can defeat that in several ways (`shell:` override, `set +e`,
`|| true`, a trailing pipeline). None of those were present: no `shell:`
key on the step, no `set +e`, no error suppression. GitHub Actions' default
shell for `run:` steps is `bash --noprofile --norc -eo pipefail {0}` - `-e`
is on by default - so the existing block already aborted before running
`release-pr` if `github-release` exited non-zero. **This is a pure
refactor, not a bug fix**: the split preserves already-correct behavior
via default step semantics instead of relying on in-script `set -e`.

## Before/after command-line equivalence

Both `release-please` invocations, flags/env identical before and after:

```
release-please github-release \
  --repo-url="${RELEASE_PLEASE_REPO_URL}" \
  --token="${RELEASE_PLEASE_TOKEN}" \
  --config-file="release-please-config.json" \
  --manifest-file=".release-please-manifest.json" \
  ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}

release-please release-pr \
  --repo-url="${RELEASE_PLEASE_REPO_URL}" \
  --token="${RELEASE_PLEASE_TOKEN}" \
  --config-file="release-please-config.json" \
  --manifest-file=".release-please-manifest.json" \
  ${RELEASE_PLEASE_DRY_RUN} ${RELEASE_PLEASE_VERBOSE}
```

`git diff` confirms the only additions are step boilerplate (`name:`,
duplicated `env:` block, `run: |`/`set -x` header) around the second
command - no flag, env var, or token-handling change.

## Retry on `github-release`: recommend as a follow-up, not implementing here

Both historical failures in this org (`github-workflows` 2026-07-20,
`homelab-ops-kubernetes-apps` 2026-08-17) were `github-release` dying at
`Fetching releases with cursor undefined` with GitHub's transient
`"No server is currently available to service your request."` - a listing
call, before any release/tag mutation.

I checked `release-please`'s `manifest.ts` (v17.11.1, the version this repo
pins) for `createReleases()` (what the `github-release` CLI command calls
in manifest mode, matching this workflow's mode since no `release-type` is
set): it iterates candidate releases, attempts to create each GitHub
release, and specifically catches `DuplicateReleaseError` - logging a
warning and treating it as already-done rather than crashing or creating a
second release. So a re-run after a tag/release was already created
should not double-create the release. That's reassuring, but:

- It's evidence read via a fetch/summarization pass over the source, not a
  full first-hand read with a local checkout - I'd want more confidence
  before writing a retry into this repo's own release path.
- After creating (or finding a duplicate) release, the code still goes on
  to comment on and relabel the source PR. I did not verify that step is
  equally idempotent - a retry that re-fires after a partial failure late
  in the run could plausibly leave a duplicate comment on the PR (cosmetic,
  but unverified).
- This is release machinery: a bad retry here (per the task's own framing)
  "double-tags", and any mistake would only surface at the next real
  release, which no CI run can exercise ahead of time.

Given the split's whole purpose is diagnostic clarity without expanding
scope, and the observed failures were transient 5xxs on a listing call
(where a human re-running the job already resolves it in under a minute),
I'm recommending a bounded retry (inline bash loop, backoff, 2-3 attempts,
scoped to the `github-release` step only - not `release-pr`, which is
cheap to re-run and less transient-prone) as a **follow-up**, not
implementing it in this PR.

## Verification

- `actionlint` (v1.7.12, pinned to match this repo's `lint-github-actions.yaml`,
  with the live `-shellcheck shellcheck` rule): clean.
- `yamllint --strict`: clean.
- `pre-commit run --all-files`: all hooks pass.
- `zizmor` (v1.29.0, pinned to match `lint-zizmor.yaml`) at the gate's
  actual thresholds (`--min-severity=medium --min-confidence=high
  --persona=regular`, matching `self-lint.yaml`'s call): 0 findings.

No behavior, flag, env var, or token-handling change - confirmed via the
diff and the command-line comparison above.
