### PR TITLE
docs(release): keep README usage examples pinned to the current major

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ commit SHA:
 ```yaml
 jobs:
   lint-yaml:
-    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@v4.0.0
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@v5.0.0 # x-release-please-version
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 ```
@@ -52,7 +52,7 @@ For workflows that need a GitHub App token (`release-please.yaml`, `release-sema
 ```yaml
 jobs:
   release:
-    uses: ppat/github-workflows/.github/workflows/release-please.yaml@v4.0.0
+    uses: ppat/github-workflows/.github/workflows/release-please.yaml@v5.0.0 # x-release-please-version
     secrets:
       app_id: ${{ secrets.HOMELAB_BOT_APP_ID }}
       app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,9 @@
     { "type": "test", "section": "🛠 Improvements" }
   ],
   "draft": false,
+  "extra-files": [
+    "README.md"
+  ],
   "packages": {
     ".": {
       "extra-label": "pr-type:release"


### PR DESCRIPTION
## Summary

- The README's "Usage" examples (`lint-yaml.yaml@v4.0.0`, `release-please.yaml@v4.0.0`) were a full
  major version behind the just-released v5.0.0, and this drifts on every release regardless of what
  changed.
- `ppat/validate-kubernetes-manifests` already solves this: its `release-please-config.json` lists
  `"extra-files": ["README.md"]`, and the README lines carry a trailing `# x-release-please-version`
  comment. release-please's generic file updater rewrites the semver string on any annotated line to
  the released version on every run — confirmed by reading
  `node_modules/release-please/build/src/updaters/generic.js` and by the fact that repo's own README
  is currently correct at `v0.1.12`, matching its manifest.
- This PR applies the same mechanism here: adds `extra-files: ["README.md"]` to
  `release-please-config.json`, and annotates the two `uses: ppat/github-workflows/...@vX.Y.Z` lines
  with `# x-release-please-version`. Also bumps both to the current `v5.0.0` so the README is correct
  now, not just going forward.
- Left the example's *style* alone (full-tag pin, `@vX.Y.Z`) rather than switching it to the
  SHA+comment style real consumers use (e.g. `validate-kubernetes-manifests`' own `release.yaml` pins
  `ppat/github-workflows/...@1e8ca1b... # v4.4.0`) — that's a docs-style decision, flagging it for a
  human rather than deciding it here.

## Verification

- `pre-commit run --all-files` passes (yamllint, markdownlint-cli2, JSON check, etc.).
- `python3 -c "import json; json.load(open('release-please-config.json'))"` confirms valid JSON.
- Ran `release-please release-pr --dry-run --debug --target-branch=docs/pin-readme-version` against
  this branch with the real CLI (17.11.1, same version/invocation this repo's own
  `release-please.yaml` uses). Output confirms `README.md` is now picked up by the updater pipeline:
  `README.md:  [class Generic extends DefaultUpdater]`, alongside `CHANGELOG.md` and the manifest.
- Also invoked that same `Generic` updater class directly, in-process, against this branch's actual
  `README.md` content with next-version `5.0.1` (the version the dry-run itself computed). Byte-for-byte
  result: both annotated lines go from `@v5.0.0 # x-release-please-version` to
  `@v5.0.1 # x-release-please-version`, nothing else changes.
- Did not cut a release to prove this — the dry run only proves the wiring; the next real release is
  the first end-to-end confirmation.

## What happens at the next release

release-please's `release-pr` step will include `README.md` as an extra-file target, find the two
`x-release-please-version`-annotated lines, and rewrite their semver portion to the new release version,
committed onto the release PR alongside `CHANGELOG.md` and the manifest bump — no manual README edit
needed on future releases.

## Test plan

- [x] `pre-commit run --all-files`
- [x] JSON validity check on `release-please-config.json`
- [x] `release-please release-pr --dry-run --debug` against this branch confirms `README.md` is wired
      into the updater pipeline
- [x] Direct invocation of the `Generic` updater against this branch's README confirms the exact
      byte-for-byte rewrite at the next version
- [ ] CI (self-lint, self-test-release-please) — pending