### PR TITLE
chore: define a coherent commit taxonomy anchored on whether a change reaches a consumer

### DIFF
--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -1,0 +1,197 @@
+---
+description: How to choose the type and scope of a commit in this repo, and why the choice is a release decision.
+---
+
+# Commit types and scopes
+
+commitlint gates every PR and release-please derives the version bump and the changelog from the commit header, so the
+header is a release decision, not a label. This repo squash-merges with `squash_commit_title=COMMIT_OR_PR_TITLE`, so
+on a multi-commit branch the **PR title** is what gets released — it has to be right too.
+
+The header carries two fields answering two questions: **type** is *what kind of change is this?* and **scope** is
+*which of this repo's maintenance surfaces did it change?* Never encode "which part of the repo" in the type, or "what
+kind of change" in the scope. They are independent in one direction only: a type claiming **shipped behaviour** cannot
+sit on a scope that never ships, and commitlint rejects it.
+
+## The artifact boundary
+
+Everything follows from one question, asked of whatever the commit touched:
+
+> **Does this reach a consumer?** Something *ships* if it is resolved at **consumer**-run time by the
+> artifact this repo publishes. If only this repo's own CI or local dev loop uses it, it does not.
+
+The published artifact is every `.github/workflows/*.yaml` declaring `on: workflow_call`. Two consequences that are
+easy to get backwards:
+
+- **A tool version pinned anywhere inside a reusable workflow file ships** — it changes what runs in a consumer's CI,
+  and is not "dev tooling" merely because it is a linter. The deciding construct is the **file**, not any YAML key:
+  pins live in workflow- and step-level `env:`, in a step's `with:` input, and in `mise_toml:` heredocs. `scopes.json`
+  matches on file path for that reason, so a pin in a new shape is classified correctly with no config change.
+- **Files copied into a caller's workspace ship.** `lint-commit-messages.yaml` and `release-semantic.yaml` copy
+  `package.json` + `bun.lock` into callers that have none, so the commitlint and semantic-release versions consumers
+  run are pinned here.
+
+Everything else — this repo's own pre-commit hooks, linter configs, `self-*.yaml` workflows and `test/` fixtures —
+does not ship; the reusable linters always run against the **caller's** config. The test is per-file, so one tool
+lands on both sides: `yamllint` in `.pre-commit-config.yaml` is internal, in `lint-yaml.yaml` it ships. Ask where the
+pin is, not what the tool is for.
+
+## Scopes
+
+Apply these **in order**, stopping at the first match. The ordering is what guarantees every commit lands in exactly
+one scope.
+
+| # | Scope | Matches |
+| --- | --- | --- |
+| 1 | `release` | A release cut, or a change to the release machinery |
+| 2 | `github-actions` | A `uses:` ref bumped or re-pinned — *anywhere*, and nothing else |
+| 3 | `kubernetes-api` | A Kubernetes `apiVersion:` bumped — *anywhere*, and nothing else |
+| 4 | `shipped-dependencies` | A version pin moved in a file that ships |
+| 5 | `internal-dependencies` | A *declared dependency* version moved in a file that does not ship, or a tooling config file was hand-edited |
+| 6 | `renovate` | This repo's Renovate *configuration* — never `renovate.yaml`, a reusable workflow like any other |
+| 7 | `reusable-workflows` | Hand-authored change to a `workflow_call` workflow: logic, interface, or the `README.md` contract documenting it |
+| 8 | `internal-workflows` | This repo's own CI — the `self-*.yaml` workflows and the `test/` fixtures they consume |
+| 9 | *(empty)* | Repo-level documentation or policy belonging to no single surface |
+
+Scopes 2 and 3 name a kind of *declaration*, so they are location-independent and sort above the rest. Scopes 4/5 are
+the artifact boundary; 7/8 are the same boundary for hand-written changes. Rule 5 covers *declared* versions only —
+generated content under `test/` (checksums, recorded fixtures) falls to rule 8 even when a bot writes it, so the
+`update-aqua-checksums` run driven by `self-test-aqua.yaml` commits as `test(internal-workflows):`.
+
+When a commit spans surfaces, scope it to the one that **motivated** it — a `README.md` update documenting a new input
+rides with `reusable-workflows`. If it genuinely has two motivations, split it. Do not propose per-workflow scopes:
+GitHub supports no subdirectories under `.github/workflows/` and a `uses:` ref cannot point into one, so the filename
+prefix is the only grouping available, and the subject already names the file.
+
+## Types
+
+Allowed: `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `test`.
+
+`build` and `style` are deliberately **not** allowed: this repo has no build system, `style` is redundant with
+`refactor`/`chore`, and `build` is hidden from the changelog — a legal type with no local meaning whose use would
+vanish silently. `revert` is kept despite going unused: its meaning is fixed, the parser and release-please
+special-case it, and it is the one type you cannot improvise mid-incident.
+
+`feat`/`fix`/`perf`/`refactor` assert something about **shipped behaviour**; the subject-matter types `ci`, `test`,
+`docs`, `chore` describe the *kind of thing* changed and take precedence when they apply.
+
+| Change | Header |
+| --- | --- |
+| New input or capability on a reusable workflow | `feat(reusable-workflows):` |
+| Behaviour correction in a reusable workflow | `fix(reusable-workflows):` |
+| Speedup or internal restructure of a reusable workflow | `perf` / `refactor(reusable-workflows):` |
+| Anything in `self-*.yaml`, **including fixing a genuine bug in one** | `ci(internal-workflows):` |
+| A fixture under `test/` | `test(internal-workflows):` |
+| Hand-edit to a tooling config file | `chore(internal-dependencies):` |
+| Repo docs on their own | `docs:` |
+| Cutting a release | `chore(release):` — release-please writes this |
+
+**A type claiming shipped behaviour cannot sit on a non-shipping scope**, and `commitlint.config.js` rejects the
+combination. That single constraint keeps ✨ Features and 🚀 Enhancements + Bug Fixes free of internal churn *without
+hiding anything* — internal surfaces are pushed onto `chore`/`ci`/`test`/`docs`, which are either hidden or plainly
+self-labelled.
+
+**Why `ci`, not `fix`, for a bug in `self-lint.yaml`.** Conventional Commits defines `ci` by subject matter — "changes
+to CI configuration files and scripts" — and `self-lint.yaml` *is* one, so `ci` is accurate and the word "fix" belongs
+in the subject. `fix` would assert a correction to shipped behaviour, which is the false claim.
+
+This is not a workaround for changelog visibility: `changelog-sections` keys on **type only** (its schema accepts
+`{type, section, hidden}` — no scope key) and `exclude-paths` matches directory prefixes with no globs, so neither can
+target `self-*.yaml`. Type is the only hiding mechanism there is, and here it is also the honest one. There is no
+escape hatch — `fix(internal-workflows)` is rejected. If a `self-*.yaml` change genuinely affects consumers, it
+belongs in a reusable workflow.
+
+**Hidden types can suppress the release entirely.** release-please renders the notes first, then skips the release
+when the result is empty (`changelogEmpty()` in `strategies/base.ts`). A window of **only** hidden types (`ci`,
+`test`) cuts no version and no tag; any visible type cuts one — a release can come from `chore` alone, which is why
+`chore` is not hidden. Version *size* is computed separately, unaffected by visibility: breaking → major, `feat` →
+minor, else patch.
+
+## What belongs under `chore`
+
+`chore` is the catch-all and is **visible** in consumers' release notes — deliberately, since most `chore` commits are
+pin, digest and lockfile updates on `shipped-dependencies` and `github-actions`, which change what runs in a
+consumer's CI. The cost is that a miscategorised `chore` lands in front of that audience.
+
+| `chore` **may** carry | `chore` **must never** carry |
+| --- | --- |
+| Renovate pin / digest / lockfile updates | A change to what a reusable workflow *does* |
+| Hand-edits to tooling config that change no shipped behaviour | A genuine bug fix, anywhere |
+| `chore(release)` — release-please's own cut | Documentation, fixtures, or internal CI config |
+| | **Anything breaking** |
+
+`chore!` is a contradiction — a change forcing consumers to act is not housekeeping; give it the type that describes
+what changed, plus `!`. "It was only a small fix" is no reason to reach for `chore`: `fix` for shipped behaviour, `ci`
+for `self-*.yaml`. One leak is accepted — `chore(internal-dependencies)` appears in consumers' notes and alone cuts a
+patch release; hiding `chore` would suppress the pin updates that are the section's point.
+
+## Breaking changes
+
+Mark them with **`!` after the type and optional scope** — `feat(reusable-workflows)!:`. release-please keys on the
+`!` alone and emits `### ⚠ BREAKING CHANGES` from it even with no footer; add a `BREAKING CHANGE: <what consumers must
+do>` footer anyway, since release-please prints it when present and falls back to the subject line when absent. The
+footer needs the colon and a description — a bare `BREAKING CHANGE` line parses as nothing. **`!` cuts a major release
+here**, moving every consumer's pin, so use it deliberately.
+
+What counts as breaking follows from the artifact boundary, but the test differs by author:
+
+- **A change you write by hand** — judge the consumer contract. Non-shipping scopes (`internal-dependencies`,
+  `internal-workflows`, `renovate`, `kubernetes-api`) are **never** breaking. Shipping scopes are breaking only if a
+  consumer on the current major must change their calling workflow or their repo: an input, output or secret removed
+  or renamed, a default changed, a new required permission or runner.
+- **A dependency bump** — the test is the version, not the judgement. Renovate cannot read an upstream changelog, and
+  asking a human to decide on every bump means it never gets decided, so **a major of anything that ships carries
+  `!`**, decided mechanically from the file the pin lives in:
+
+| Major update to… | Header |
+| --- | --- |
+| a pin inside a reusable workflow | `feat(shipped-dependencies)!:` |
+| `package.json` / `bun.lock` | `feat(shipped-dependencies)!:` |
+| a `uses:` ref inside a reusable workflow | `feat(github-actions)!:` |
+| anything in a `self-*.yaml` | `chore(internal-dependencies):` — no `!` |
+| `.pre-commit-config.yaml`, `test/` fixtures, `kubernetes-api` | no `!` |
+
+Renovate has no "emit a breaking marker" setting, so these rules hand-build the header with `commitMessagePrefix` plus
+`semanticCommits: "disabled"` — supplying a prefix suppresses Renovate's own semantic-prefix assembly, which is what
+makes `!` stick.
+
+**The consequence is deliberate: every major bump of a shipped dependency cuts a major release of this repo** —
+accuracy bought at the cost of version-number economy. A consumer on the previous major is unaffected until they move
+their pin, which is what a major is for; shipping a changed tool under a patch bump would hide it. Those majors also
+get `automerge: false`, asserted explicitly rather than inherited because a shared preset can re-enable automerge for
+a package pattern without filtering on update type.
+
+**The commit body is cleared, not filled.** `commitBody` sits behind a truthy check
+(`workers/repository/update/branch/index.js`), so `""` is identical to unset; it is not release notes (those go in the
+PR body) nor the dependency table (`commitBodyTable`, separate, default `false`, never enabled here). Major bumps
+arrive carrying a bare `BREAKING CHANGE` line — no colon, so it parses as nothing while conflicting with the `!`
+convention — and clearing it loses only that. Filling it with a real footer is worse: with no footer release-please
+prints the **subject line**, naming the dependency and both versions, rather than one fixed sentence repeated on every
+entry.
+
+## What Renovate emits, and why it must match
+
+`scope-enum` must accept every scope Renovate can produce, or its PRs are rejected and dependency updates stop.
+`.github/renovate/scopes.json` maps Renovate's output onto the scopes above and is loaded last so its rules win.
+Renovate picks its type from the dependency's semver level (`feat` major/minor, `fix` patch/digest, `chore`
+pin/lockfile); leave its titles alone.
+
+**Re-run the enumeration whenever the shared-preset pin moves** — an upstream rule that starts matching a manager this
+repo uses reopens the emission-vs-acceptance gap with no local change. `scopes.json` is written to be **invariant**
+across such a bump (it claims each scope unconditionally and restores the semver-derived type explicitly), so emitted
+headers do not depend on which preset version is pinned. Verify that rather than assuming it. Two rules of thumb:
+
+- **Claim the scope with no `matchUpdateTypes`.** A scope rule enumerating update types leaves the unnamed ones
+  (`replacement`, `rollback`, `bump`) to fall through to an upstream scope this repo rejects.
+- **Never assume a type survives.** If an upstream rule may force `semanticCommitType`, restore the type here rather
+  than relying on the upstream update-type mapping reaching the end of the chain.
+
+**Classify by file, never by package name.** The Renovate CLI is the worked example: pinned in `renovate.yaml` and
+`lint-renovate-config-check.yaml`, both `workflow_call` workflows, so it **ships** even though an upstream rule
+matches it by package name and would call it internal — do not add a package-name rule to correct that. Equally, do
+not narrow the manager-level defaults to exclude `bun` because `package.json` ships: the SHIPS rule promotes it, and
+that default is what stops a dep the narrower upstream matchers miss from landing on the empty scope.
+
+Every rule in `scopes.json` must earn its place: remove each in turn and re-resolve the whole set, and a rule changing
+nothing in either reachable or latent cells is dead. Run that before adding a rule and after any preset upgrade — a
+rule load-bearing under one preset version can go dead under the next.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,13 +33,14 @@
     "mergeConfidence:age-confidence-badges",
     "mergeConfidence:all-badges",
     "workarounds:k3sKubernetesVersioning",
-    "github>ppat/renovate-presets#v0.2.1",
-    "github>ppat/renovate-presets:dev-tools#v0.2.1",
-    "github>ppat/renovate-presets:github-actions-provider#v0.2.1",
-    "github>ppat/renovate-presets:kubernetes#v0.2.1",
+    "github>ppat/renovate-presets#v1.0.0",
+    "github>ppat/renovate-presets:dev-tools#v1.0.0",
+    "github>ppat/renovate-presets:github-actions-provider#v1.0.0",
+    "github>ppat/renovate-presets:kubernetes#v1.0.0",
     "github>ppat/github-workflows//.github/renovate/release-age",
     "github>ppat/github-workflows//.github/renovate/group",
-    "github>ppat/github-workflows//.github/renovate/exceptions"
+    "github>ppat/github-workflows//.github/renovate/exceptions",
+    "github>ppat/github-workflows//.github/renovate/scopes"
   ],
   "internalChecksFilter": "strict",
   "labels": [

--- a/.github/renovate/scopes.json
+++ b/.github/renovate/scopes.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "CONSERVATIVE DEFAULT: the shared presets classify these managers as internal-dependencies, but with narrower matchers -- bun/npm/poetry only for dev depTypes, mise only at the repo root. This claims the scope for the whole manager so a dep those matchers miss cannot fall through to the empty scope, which is reserved for repo-level policy. The file-based SHIPS rules below promote the ones that do reach a consumer",
+      "commitBody": "",
+      "matchManagers": [
+        "bun",
+        "mise",
+        "npm",
+        "pep621",
+        "poetry",
+        "pre-commit"
+      ],
+      "semanticCommitScope": "internal-dependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "CONSERVATIVE DEFAULT: a lockfile refresh carries no semver level, so nothing derives its scope. Default it to internal-dependencies and let the file-based rule further down promote the one lockfile that does ship. Placed before that rule deliberately -- later rules win. Also covers the upstream rule that matches lockFileMaintenance with no manager filter",
+      "commitBody": "",
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "semanticCommitScope": "internal-dependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "CONSERVATIVE DEFAULT: this repo's custom regex managers scan every *.yaml and every Dockerfile, not just workflows, so a '# renovate:' pin can land outside a shipped path (.pre-commit-config.yaml, zizmor.yaml, a fixture). Default those to internal-dependencies instead of letting them fall through to the empty scope, which is reserved for repo-level policy. The file-based SHIPS rule below promotes the ones inside reusable workflows",
+      "commitBody": "",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "semanticCommitScope": "internal-dependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "SHIPS: any version pinned anywhere inside a reusable workflow file is resolved in the caller's CI. The extglob excludes self-*.yaml, so this selects exactly what it claims and does not depend on a later rule to undo it. No matchUpdateTypes on purpose, so no update type can fall through to an upstream scope this repo rejects",
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "semanticCommitScope": "shipped-dependencies"
+    },
+    {
+      "description": "restore the semver-derived type for reusable-workflow pins (self-*.yaml excluded by the extglob) -- major/minor. dev-tools.json rule 7 forces 'chore' on the renovate CLI, which ships",
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "semanticCommitType": "feat"
+    },
+    {
+      "description": "restore the semver-derived type for reusable-workflow pins (self-*.yaml excluded by the extglob) -- patch/digest",
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "semanticCommitType": "fix"
+    },
+    {
+      "description": "SHIPS: package.json/bun.lock are copied into the caller's workspace by lint-commit-messages and release-semantic. No matchUpdateTypes, for the same reason as above",
+      "commitMessageExtra": "({{currentVersion}} -> {{newVersion}})",
+      "matchFileNames": [
+        "package.json"
+      ],
+      "matchManagers": [
+        "bun",
+        "npm"
+      ],
+      "semanticCommitScope": "shipped-dependencies"
+    },
+    {
+      "description": "restore the semver-derived type for package.json -- major/minor. renovate-presets>=v0.3.0 adds 'bun' to dev-tools.json rule 1, which forces 'chore' on deps that ship",
+      "matchFileNames": [
+        "package.json"
+      ],
+      "matchManagers": [
+        "bun",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "semanticCommitType": "feat"
+    },
+    {
+      "description": "restore the semver-derived type for package.json -- patch/digest",
+      "matchFileNames": [
+        "package.json"
+      ],
+      "matchManagers": [
+        "bun",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "semanticCommitType": "fix"
+    },
+    {
+      "description": "SHIPS: bun.lock is copied into the caller's workspace alongside package.json, so refreshing it is consumer-facing. Matched by lock file name -- matchFileNames tests packageFile and every lockFiles entry, so the lock file itself is nameable. The repo's other lock file, test/terraform/.terraform.lock.hcl, is a fixture and is deliberately absent from this list. lockFileMaintenance has no semver level, so the type is chore by construction and cannot reach the major-only breaking rules below",
+      "matchFileNames": [
+        "bun.lock",
+        "package.json"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "semanticCommitScope": "shipped-dependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "INTERNAL CARVE-OUT: a 'uses:' bump in this repo's own workflows keeps scope github-actions -- that scope is location-independent by convention -- but takes type chore, because nothing a consumer runs changed. Without this it inherits feat/fix from the update type and an internal-only bump cuts a release consumers see",
+      "commitBody": "",
+      "matchFileNames": [
+        ".github/workflows/self-*.yaml"
+      ],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "kubernetes-api deps here live only in test/chainsaw fixtures, so a bump cannot break a consumer: strip the '!' and the BREAKING CHANGE body that renovate-presets:kubernetes emits",
+      "commitBody": "",
+      "commitMessagePrefix": "chore(kubernetes-api):",
+      "matchDatasources": [
+        "kubernetes-api"
+      ],
+      "semanticCommits": "disabled"
+    },
+    {
+      "description": "a major of anything that ships must not merge itself: it cuts a major release. Matcher is ships-only, so internal majors automerge as normal. Also counters a shared preset that enables automerge for a package pattern without filtering on update type",
+      "automerge": false,
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml",
+        "package.json",
+        "bun.lock"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "description": "NO BREAKING MARKER by default: the shared default preset marks every major breaking, which is the right conservative default but wrong here for anything that cannot reach a consumer. Strip it back to a plain prefix, then let the BREAKING MARKER rules below re-add '!' for the paths that do ship. Excludes the kubernetes manager so the kubernetes-api rule above keeps its own prefix",
+      "commitMessagePrefix": "{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}:",
+      "matchManagers": [
+        "bun",
+        "custom.regex",
+        "github-actions",
+        "mise",
+        "npm",
+        "pep621",
+        "poetry",
+        "pre-commit"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "description": "BREAKING MARKER: a major of a dependency that ships is breaking for consumers by construction, so emit '!' mechanically -- reusable-workflow pins",
+      "commitMessagePrefix": "feat(shipped-dependencies)!:",
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommits": "disabled"
+    },
+    {
+      "description": "BREAKING MARKER: same, for the package.json/bun.lock that get copied into the caller's workspace",
+      "commitMessagePrefix": "feat(shipped-dependencies)!:",
+      "matchFileNames": [
+        "package.json"
+      ],
+      "matchManagers": [
+        "bun",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommits": "disabled"
+    },
+    {
+      "description": "BREAKING MARKER: same, for a 'uses:' ref inside a reusable workflow -- it runs in the caller's CI just as a pinned tool does",
+      "commitMessagePrefix": "feat(github-actions)!:",
+      "matchFileNames": [
+        ".github/workflows/!(self-*).yaml"
+      ],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommits": "disabled"
+    }
+  ]
+}

--- a/.github/workflows/self-test-aqua.yaml
+++ b/.github/workflows/self-test-aqua.yaml
@@ -26,6 +26,10 @@ jobs:
       git_ref: ${{ github.head_ref || github.ref_name }}
       aqua_dirs: |
         test/aqua
+      # the checksums this pushes land in test/aqua/, a fixture of this repo's own CI -- override the
+      # reusable workflow's consumer-facing defaults so the bot's commit passes this repo's scope-enum
+      semantic_commit_type: test
+      semantic_commit_scope: internal-workflows
     secrets:
       app_id: ${{ secrets.HOMELAB_BOT_APP_ID }}
       app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ comment at the occurrence, never with a repo-wide disable.
 Lint a commit message locally:
 
 ```bash
-echo "fix(github-actions): pin actions/checkout to v7" | npx commitlint
+echo "fix(github-actions): re-pin actions/checkout to its current major" | npx commitlint
 ```
 
 `bun install` is only needed if changing `package.json`/`.releaserc.js` (semantic-release deps); it is not
@@ -63,6 +63,17 @@ push a branch/PR that touches it (or its `test/<name>/` fixtures), which trigger
 `self-test-<name>.yaml` in GitHub Actions. These also run weekly and via `workflow_dispatch`, so a
 passing run days ago doesn't guarantee the workflow still works against current upstream tool versions.
 
+## Commit types and scopes
+
+The full taxonomy lives in [.claude/rules/commits.md](.claude/rules/commits.md) — read it before writing
+a commit message or a PR title. In short: **type** answers *what kind of change*, **scope** answers *which
+maintenance surface*, and the split between them turns on one question — does the thing you changed reach
+a consumer, or only this repo's own CI? commitlint enforces both the scope list and the rule that a type
+claiming shipped behaviour cannot sit on a scope that never ships.
+
+This matters more than it looks: release-please derives the version bump and the changelog from the
+header, and squash-merge means the **PR title** is the released commit on a multi-commit branch.
+
 ## Working in this repo
 
 - Every reusable workflow takes `git_ref` (or `source_git_ref`) as an explicit input rather than assuming
@@ -72,6 +83,14 @@ passing run days ago doesn't guarantee the workflow still works against current 
 - When changing a reusable workflow's inputs, outputs, or secrets, update its matching table row in
   [README.md](README.md) in the same change — README is the interface contract consumers read before
   wiring a `with:`/`secrets:` block, not just a summary.
+- An input's **default** is part of that interface too. Change one only for consumers' sake, never to suit
+  this repo — override it at the call site instead, as `self-test-aqua.yaml` does for
+  `update-aqua-checksums.yaml`'s `semantic_commit_scope`. Changing a default is a breaking change and
+  belongs with a coordinated rollout.
+- An input's **default** is part of that interface too. Change one only for consumers' sake, never to suit
+  this repo — override it at the call site instead, as `self-test-aqua.yaml` does for
+  `update-aqua-checksums.yaml`'s `semantic_commit_scope`. Changing a default is a breaking change and
+  belongs with a coordinated rollout.
 - If a workflow's runtime behavior changed (not just its `with:`/`secrets:` surface), check whether a
   matching `self-test-<name>.yaml` + `test/<name>/` fixture exists and update it rather than relying on
   manual verification — see [DESIGN.md](DESIGN.md) for the dogfooding pattern this repo uses.
@@ -81,10 +100,9 @@ passing run days ago doesn't guarantee the workflow still works against current 
   than inventing a new comment format.
 - Pin any new third-party Action reference to a commit SHA with the version as a trailing comment
   (`uses: owner/repo@<sha> # vX.Y.Z`).
-- Commit messages must pass commitlint: conventional-commit format, scope must be one of `dev-tools`,
-  `github-actions`, `release`, `renovate`, or empty, header ≤120 chars. `CHANGELOG.md` and version numbers
-  are otherwise fully automated by release-please (this repo's own release mechanism, see
-  [DESIGN.md](DESIGN.md)) — don't hand-edit either.
+- Commit messages must pass commitlint (header ≤120 chars) — see
+  [.claude/rules/commits.md](.claude/rules/commits.md) for which type/scope to pick. `CHANGELOG.md` and version numbers are fully automated by release-please (this
+  repo's own release mechanism, see [DESIGN.md](DESIGN.md)) — don't hand-edit either.
 - This repo offers both `release-please.yaml` and `release-semantic.yaml` as reusable workflows for
   consumers to pick one from, but only dogfoods `release-please` on itself. Don't assume the two are
   interchangeable or that a change to one should mirror in the other — they're deliberately separate

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -110,9 +110,11 @@ above) rather than one being left to bit-rot in favor of the other. Don't take o
 consumer repos from one to the other without being asked — pick whichever mechanism a given repo already
 uses, or ask, rather than assuming `release-please` is always the right default going forward.
 
-Commit messages are enforced by commitlint (`commitlint.config.js`, scopes limited to
-`dev-tools`/`github-actions`/`release`/`renovate`/empty) via `lint-commit-messages.yaml`. `CHANGELOG.md` and
-version numbers are fully automated by whichever mechanism a repo uses — don't hand-edit either.
+Commit messages are enforced by commitlint (`commitlint.config.js`) via `lint-commit-messages.yaml`. The
+type/scope taxonomy those rules encode — and the artifact boundary that decides it — is documented in
+[.claude/rules/commits.md](.claude/rules/commits.md); it is not restated here, so there is one source of
+truth. `CHANGELOG.md` and version numbers are fully automated by whichever mechanism a repo uses — don't
+hand-edit either.
 
 ## Dependency updates
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,13 +1,38 @@
+// Scopes that only ever carry machine-generated dependency updates. Renovate formats those bodies
+// itself, so they are exempt from the body line-length limit.
+// NOTE: this used to test for `chore(deps)`, which 'scope-enum' below does not allow and Renovate
+// never emits here -- the exemption was unreachable. These are the scopes it actually produces.
+const dependencyUpdateScopes = ['github-actions', 'internal-dependencies', 'kubernetes-api', 'shipped-dependencies']
+
+// A type that asserts a change to *shipped* behaviour may only be paired with a scope that can
+// actually reach a consumer. This is what keeps the consumer changelog's Features / Enhancements
+// sections free of internal churn without hiding anything: internal surfaces take chore/ci/test/docs,
+// which are either hidden or self-labelled. See .claude/rules/commits.md.
+const shippedBehaviourTypes = ['feat', 'fix', 'perf', 'refactor']
+const scopesThatCanShip = ['', 'github-actions', 'release', 'reusable-workflows', 'shipped-dependencies']
+
+const validateTypeScopePairing = (parsedCommit) => {
+  const { type, scope } = parsedCommit
+  const isShippedBehaviourClaim = shippedBehaviourTypes.includes(type)
+
+  return [
+    !isShippedBehaviourClaim || scopesThatCanShip.includes(scope || ''),
+    `type '${type}' asserts a change to shipped behaviour and cannot be used with scope '${scope}', ` +
+    `which never reaches a consumer -- use chore, ci, test or docs instead (see .claude/rules/commits.md)`,
+  ]
+}
+
 const validateBodyMaxLengthIgnoringDeps = async (parsedCommit) => {
   const { maxLineLength } = await import('@commitlint/ensure');
 
-  const { type, scope, body } = parsedCommit
-  const isDepsCommit = type === 'chore' && scope === 'deps'
+  const { scope, subject, body } = parsedCommit
+  const isDependencyUpdate =
+    dependencyUpdateScopes.includes(scope) && /^(update|pin) /.test(subject || '')
 
   const bodyMaxLineLength = 120;
 
   return [
-    isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),
+    isDependencyUpdate || !body || maxLineLength(body, bodyMaxLineLength),
     `commit message body line length must not exceed ${bodyMaxLineLength}`,
   ]
 }
@@ -30,14 +55,40 @@ module.exports = {
       validateBodyMaxLengthIgnoringDeps
     ],
 
-    // specify the allowed scopes
+    // reject type/scope pairings that claim shipped behaviour on a scope that cannot ship
+    'function-rules/scope-enum': [2, 'always', validateTypeScopePairing],
+
+    // restrict the types allowed by @commitlint/config-conventional. Dropped: 'build' (this repo has
+    // no build system -- 0 uses in 586 commits, and it is hidden from the changelog, so a stray one
+    // would vanish silently) and 'style' (redundant with refactor/chore here -- 0 uses). 'revert' is
+    // kept despite 0 uses: it has a fixed meaning, the parser special-cases it, and it is the one
+    // type you cannot substitute under time pressure.
+    'type-enum': [2, 'always',
+      [
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'test'
+      ]
+    ],
+
+    // specify the allowed scopes -- see "Commit types and scopes" in CLAUDE.md for what each one means
     'scope-enum': [2, 'always',
       [
         '',
-        'dev-tools',
         'github-actions',
+        'internal-dependencies',
+        'internal-workflows',
+        'kubernetes-api',
         'release',
-        'renovate'
+        'renovate',
+        'reusable-workflows',
+        'shipped-dependencies'
       ]
     ],
     // 'scope-empty': [2, 'always'],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,17 +1,14 @@
 {
   "changelog-sections": [
-    { "type": "build", "section": "🏗️ Build System", "hidden": true },
     { "type": "chore", "section": "🧹 Miscellaneous", "hidden": false },
     { "type": "ci", "section": "🚦 Continuous Integration", "hidden": true },
     { "type": "docs", "section": "🛠 Improvements" },
     { "type": "feat", "section": "✨ Features" },
-    { "type": "feature", "section": "✨ Features" },
     { "type": "fix", "section": "🚀 Enhancements + Bug Fixes" },
     { "type": "perf", "section": "🚀 Enhancements + Bug Fixes" },
     { "type": "refactor", "section": "🚀 Enhancements + Bug Fixes" },
     { "type": "revert", "section": "⚙️ Other" },
-    { "type": "style", "section": "🛠 Improvements" },
-    { "type": "test", "section": "🛠 Improvements" }
+    { "type": "test", "section": "🛠 Improvements", "hidden": true }
   ],
   "draft": false,
   "extra-files": [


### PR DESCRIPTION
## The problem

Every scope this repo allowed named a category of dependency or process — `dev-tools`, `github-actions`,
`release`, `renovate` — and **none named the product**. Product changes drifted into `github-actions`,
which came to mean two unrelated things: a third-party action being bumped, and a genuine change to a
reusable workflow. A consumer reading the changelog could not tell which entries affected the workflow
they call.

## The rule

One question, asked of whatever the commit touched:

> **Does this reach a consumer?** Something *ships* if it is resolved at **consumer**-run time by the
> artifact this repo publishes — here, the workflows declaring `on: workflow_call`.

Decidable from the diff, because it turns on **which file a pin lives in**, not what the tool is for. The
same linter is internal in `.pre-commit-config.yaml` and shipped in `lint-yaml.yaml`. `package.json` and
`bun.lock` ship too — `lint-commit-messages.yaml` and `release-semantic.yaml` copy them into callers that
have none, so the commitlint and semantic-release versions consumers run are pinned here.

## What changed

| File | Change |
| --- | --- |
| `commitlint.config.js` | nine scopes; `type-enum` added; a function rule rejecting shipped-behaviour types on non-shipping scopes; repaired body-length exemption |
| `release-please-config.json` | `test` hidden; sections dropped for types no longer accepted |
| `.github/renovate/scopes.json` | **new** — maps what Renovate emits onto those scopes, and marks breaking changes mechanically |
| `.github/renovate.json` | loads the above last; preset pin moved to the release carrying the shared vocabulary |
| `.github/workflows/self-test-aqua.yaml` | overrides the commit scope at the call site |
| `.claude/rules/commits.md` | **new** — the taxonomy, as a decision procedure |
| `CLAUDE.md` / `DESIGN.md` | point at it instead of restating a scope list that had gone stale |

**Type answers what kind of change; scope answers which surface.** A type claiming shipped behaviour
cannot sit on a scope that never ships, and commitlint rejects the combination — which is what keeps
✨ Features and 🚀 Enhancements + Bug Fixes free of internal churn *without hiding anything*.

## ⚠️ Two consequences worth seeing before merge

**Every major bump of a shipped dependency now cuts a major release.** The breaking marker is mechanical —
a major of anything that ships carries `!`, decided from the file rather than left to a reviewer who will
never make that call on a dependency PR. Accuracy over version-number economy: a consumer on the previous
major is unaffected until they move their pin, whereas shipping a changed tool under a patch bump hides
it. Expect the major number to move faster.

**`ci`, not `fix`, for a bug in a `self-*.yaml`.** Conventional Commits defines `ci` by subject matter, so
it is the accurate type; `fix` would assert a correction to *shipped* behaviour. This is not a changelog
dodge — `changelog-sections` keys on type only and `exclude-paths` matches directory prefixes with no
globs, so neither can target `self-*.yaml`. There is deliberately no escape hatch.

## Verification

Resolved the fully expanded rule set through **Renovate's own `applyPackageRules`** at the pinned version,
across every tracked file × manager × update type × datasource × the package names any rule keys on.

That found **two leaks no output-based check could reach**, because they lived in combinations nothing
triggers yet — a scope commitlint would have rejected, and pins landing on the empty scope reserved for
repo-level policy. Each local rule was then removed in turn and the set re-resolved; **four that changed
nothing in either reachable or latent cells were deleted.**

Across the reachable cells: no scope commitlint would reject, none contradicting a file's ship status, no
marker on anything internal, none missing from anything shipped, no automerge on a shipped major, no
commit body. Every header Renovate can emit passes commitlint.

Also clean: `markdownlint`, `pre-commit --all-files`, `actionlint`, and a synthetic commitlint suite
covering every allowed scope plus the forms that must be rejected.

## Upstream work this depends on

The shared-vocabulary half landed separately in `ppat/renovate-presets` (v1.0.0): the scope rename, an
inert `groupName`, the unparseable `BREAKING CHANGE` body replaced with a real header marker, the
kubernetes rules aligned with their descriptions, and a `CLAUDE.md` for that repo. Remaining follow-ups
are tracked there as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
